### PR TITLE
fix: ConsumerVersionSelector interface (BREAKING CHANGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ pact.verifyPacts({
 | `providerBaseUrl`           | true      | string  | Running API provider host endpoint.                                                                        |
 | `pactBrokerUrl`         | false     | string  | Base URL of the Pact Broker from which to retrieve the pacts. Required if `pactUrls` not given.                                                                        |
 | `provider`                  | false     | string  | Name of the provider if fetching from a Broker                                                             |
-| `consumerVersionSelectors`        | false     | ConsumerVersionSelector\|array  | Use [Selectors](https://docs.pact.io/selectors) to is a way we specify which pacticipants and versions we want to use when configuring verifications.                                                         |
+| `consumerVersionSelectors`        | false     | ConsumerVersionSelector\|array  | Use [Selectors](https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors) to is a way we specify which pacticipants and versions we want to use when configuring verifications.                                                         |
 | `consumerVersionTags`        | false     | string\|array  | Retrieve the latest pacts with given tag(s)                                                        |
 | `providerVersionTags`        | false     | string\|array  |  Tag(s) to apply to the provider application |
 | `includeWipPactsSince`      | false     | string  | Includes pact marked as WIP since this date. String in the format %Y-%m-%d or %Y-%m-%dT%H:%M:%S.000%:z |

--- a/src/spawn/arguments.spec.ts
+++ b/src/spawn/arguments.spec.ts
@@ -42,7 +42,7 @@ describe('Pact Util Spec', () => {
             {
               consumerVersionSelectors: [
                 {
-                  all: true,
+                  latest: true,
                   tag: 'prod',
                 },
                 {
@@ -56,7 +56,7 @@ describe('Pact Util Spec', () => {
           expect(result)
             .to.be.an('array')
             .that.includes('--consumer-version-selector')
-            .and.includes('{"all":true,"tag":"prod"}')
+            .and.includes('{"latest":true,"tag":"prod"}')
             .and.includes('{"tag":"bar"}');
           expect(result.length).to.be.equal(4);
         });
@@ -128,7 +128,7 @@ describe('Pact Util Spec', () => {
               {
                 consumerVersionSelectors: [
                   {
-                    all: true,
+                    latest: true,
                     tag: 'prod',
                   },
                 ],
@@ -147,7 +147,7 @@ describe('Pact Util Spec', () => {
           expect(result)
             .to.be.an('array')
             .that.includes('--consumer-version-selector')
-            .and.includes('{"all":true,"tag":"prod"}')
+            .and.includes('{"latest":true,"tag":"prod"}')
             .and.includes('{"tag":"foo"}');
           expect(result.length).to.be.equal(4);
         });

--- a/src/verifier.ts
+++ b/src/verifier.ts
@@ -287,13 +287,12 @@ export default (options: VerifierOptions): Verifier => new Verifier(options);
 // A ConsumerVersionSelector is a way we specify which pacticipants and
 // versions we want to use when configuring verifications.
 //
-// See https://docs.pact.io/selectors for more
+// See https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors for more
 export interface ConsumerVersionSelector {
-  pacticipant?: string;
   tag?: string;
-  version?: string;
   latest?: boolean;
-  all?: boolean;
+  consumer?: string;
+  fallbackTag?: string;
 }
 
 interface CurrentVerifierOptions {


### PR DESCRIPTION
Fix incompatible `ConsumerVersionSelector` interface attributes based on [new pact_broker docs](https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors/)

Fix: https://github.com/pact-foundation/pact-js/issues/649 and https://github.com/pact-foundation/pact-js-core/issues/285




