### PR TITLE
feat: add build url on pact publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ pact.publishPacts(opts).then(function () {
 | `pactBrokerPassword` | false     | string | Password for Pact Broker basic authentication. Optional             |
 | `pactBrokerToken`    | false     | string | Bearer token for Pact Broker authentication. Optional               |
 | `tags`               | false     | array  | An array of Strings to tag the Pacts being published. Optional      |
+| `buildUrl`           | false     | string | The build URL that created the pact. Optional                       |
 | `verbose`           |  false  | boolean | Enables verbose output for underlying pact binary. |
 
 ### Pact Broker Deployment Check

--- a/src/publisher.ts
+++ b/src/publisher.ts
@@ -18,6 +18,7 @@ export class Publisher {
     tags: '--tag',
     consumerVersion: '--consumer-app-version',
     verbose: '--verbose',
+    buildUrl: '--build-url',
   };
 
   constructor(options: PublisherOptions) {
@@ -148,4 +149,5 @@ export interface PublisherOptions {
   tags?: string[];
   verbose?: boolean;
   timeout?: number;
+  buildUrl?: string;
 }

--- a/test/publisher.integration.spec.ts
+++ b/test/publisher.integration.spec.ts
@@ -37,6 +37,7 @@ describe('Publish Spec', () => {
               ),
             ],
             consumerVersion: '1.0.0',
+            buildUrl: 'http://ci/build/1',
           });
 
           expect(publisher).to.be.a('object');


### PR DESCRIPTION
Add `buildUrl` parameter for the pact publication function. Follow-up for https://github.com/pact-foundation/pact-js-core/issues/352