### PR TITLE
feat: collect usage telemetry data

### DIFF
--- a/src/spawn/spawn.ts
+++ b/src/spawn/spawn.ts
@@ -17,6 +17,10 @@ export class Spawn {
     argMapping: { [id: string]: string } = {}
   ): ChildProcess {
     const envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
+
+    envVars['PACT_EXECUTING_LANGUAGE'] = 'node.js'
+    envVars['PACT_EXECUTING_LANGUAGE_VERSION'] = process.versions.node
+
     // Remove environment variable if there
     // This is a hack to prevent some weird Travelling Ruby behaviour with Gems
     // https://github.com/pact-foundation/pact-mock-service-npm/issues/16

--- a/src/spawn/spawn.ts
+++ b/src/spawn/spawn.ts
@@ -18,8 +18,8 @@ export class Spawn {
   ): ChildProcess {
     const envVars = JSON.parse(JSON.stringify(process.env)); // Create copy of environment variables
 
-    envVars['PACT_EXECUTING_LANGUAGE'] = 'node.js'
-    envVars['PACT_EXECUTING_LANGUAGE_VERSION'] = process.versions.node
+    envVars['PACT_EXECUTING_LANGUAGE'] = 'node.js';
+    envVars['PACT_EXECUTING_LANGUAGE_VERSION'] = process.versions.node;
 
     // Remove environment variable if there
     // This is a hack to prevent some weird Travelling Ruby behaviour with Gems


### PR DESCRIPTION
This PR adds two environment variables, PACT_EXECUTING_LANGUAGE and PACT_EXECUTING_LANGUAGE_VERSION. These variables will be used to track metrics such as when consumer and provider tests are ran so that we(Pact OSS maintainers) can gain insight into what languages and versions are used for Pact. PRs for some of the metrics [here ](https://github.com/pact-foundation/pact-mock_service/pull/133) and [here](https://github.com/pact-foundation/pact-ruby/pull/256)