### PR TITLE
Fix/custom provider headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
       },
       "devDependencies": {
         "@pact-foundation/pact-js-prettier-config": "^1.0.0",
+        "@tsconfig/node14": "^1.0.3",
         "@types/basic-auth": "^1.1.2",
         "@types/bindings": "^1.5.1",
         "@types/chai": "4.1.2",
@@ -1441,9 +1442,9 @@
       "dev": true
     },
     "node_modules/@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "node_modules/@tsconfig/node16": {
@@ -11317,9 +11318,9 @@
       "dev": true
     },
     "@tsconfig/node14": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "dev": true
     },
     "@tsconfig/node16": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "devDependencies": {
     "@pact-foundation/pact-js-prettier-config": "^1.0.0",
+    "@tsconfig/node14": "^1.0.3",
     "@types/basic-auth": "^1.1.2",
     "@types/bindings": "^1.5.1",
     "@types/chai": "4.1.2",

--- a/src/verifier/nativeVerifier.ts
+++ b/src/verifier/nativeVerifier.ts
@@ -43,9 +43,11 @@ export const verify = (opts: VerifierOptions): Promise<string> => {
     );
   }
 
-  Object.keys(opts.customProviderHeaders || {}).forEach((key, _, obj) =>
-    ffi.pactffiVerifierAddCustomHeader(handle, key, obj[key])
-  );
+  if (opts.customProviderHeaders) {
+    Object.entries(opts.customProviderHeaders).forEach(([key, value]) => {
+      ffi.pactffiVerifierAddCustomHeader(handle, key, value);
+    });
+  }
 
   const filterDescription = process.env.PACT_DESCRIPTION || '';
   const filterState = process.env.PACT_PROVIDER_STATE || '';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
+  "extends": "@tsconfig/node14/tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
-    "lib": ["es6", "es2016"],
     "removeComments": true,
     "noLib": false,
     "sourceMap": true,


### PR DESCRIPTION
This PR fixes #388 - or at least, I think it does. I couldn't add a test because the tests weren't passing before I made any changes - I got a lot of:

```
AssertionError: expected promise to be fulfilled but it was rejected with 'TypeError: ffi.pactffiVerify is not a function'
```
instead. Hopefully it passes in CI.

I also removed the old tsconfig settings and replaced them with the default settings for targetting node 14, which brings in more accurate standard library typing. 