### PR TITLE
fix: corrects customProviderHeaders validation

### DIFF
--- a/src/verifier/validateOptions.spec.ts
+++ b/src/verifier/validateOptions.spec.ts
@@ -350,4 +350,15 @@ describe('Verifier argument validator', () => {
       });
     });
   });
+
+  context('when given customProviderHeaders that are defined', () => {
+    it('should pass through to the Pact Verifier', () => {
+      expect(() =>
+        validateOptions({
+          providerBaseUrl: 'http://localhost',
+          customProviderHeaders: { my: 'header' },
+        })
+      ).to.not.throw(Error);
+    });
+  });
 });

--- a/src/verifier/validateOptions.ts
+++ b/src/verifier/validateOptions.ts
@@ -175,7 +175,7 @@ export const validationRules: ArgumentValidationRules<InternalPactVerifierOption
     buildUrl: [wrapCheckType(checkTypes.assert.nonEmptyString)],
     consumerVersionSelectors: [consumerVersionSelectorValidator],
     consumerVersionTags: [consumerVersionTagsValidator],
-    customProviderHeaders: [wrapCheckType(checkTypes.assert.nonEmptyString)],
+    customProviderHeaders: [wrapCheckType(checkTypes.assert.nonEmptyObject)],
     disableSslVerification: [wrapCheckType(checkTypes.assert.boolean)],
     enablePending: [wrapCheckType(checkTypes.assert.boolean)],
     format: [deprecatedFunction],


### PR DESCRIPTION
### PR Template

This PR fixes the changes made to validation in 13.7.3 which did not support the types specified for customProviderHeaders.  


Fixes (pact-foundation/pact-js-core#392)