### PR TITLE
remove arch for Linux standalone binaries

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -26,7 +26,6 @@ export function createConfig(): Config {
       },
       {
         platform: 'linux',
-        arch: 'x64',
         binary: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz`,
         binaryChecksum: `pact-${PACT_STANDALONE_VERSION}-linux-x86_64.tar.gz${CHECKSUM_SUFFIX}`,
         folderName: `linux-x64-${PACT_STANDALONE_VERSION}`,


### PR DESCRIPTION
Currently when running on a platform that has no standalone Ruby binaries available everything using pact errors out:
```
(partly redacted)
    Error while locating pact binary: Cannot find binary for platform 'linux' with architecture 'arm64'.

    > 1 | import { Matchers, Pact } from "@pact-foundation/pact";
        | ^

      at throwError (node_modules/@pact-foundation/pact-core/standalone/install.ts:7:9)
      at Object.getBinaryEntry (node_modules/@pact-foundation/pact-core/standalone/install.ts:51:9)
      at Object.standalone (node_modules/@pact-foundation/pact-core/src/pact-standalone.ts:40:5)
      at Object.<anonymous> (node_modules/@pact-foundation/pact-core/src/pact-standalone.ts:72:16)
      at Object.<anonymous> (node_modules/@pact-foundation/pact-core/src/server.ts:2:1)
      at Object.<anonymous> (node_modules/@pact-foundation/pact-core/src/pact.ts:2:1)
      at Object.<anonymous> (node_modules/@pact-foundation/pact-core/src/index.ts:1:1)
      at Object.<anonymous> (node_modules/@pact-foundation/src/httpPact/index.ts:2:1)
      at Object.<anonymous> (node_modules/@pact-foundation/src/index.ts:25:1)
```

I'm using the submitted diff with [patch-package](https://www.npmjs.com/package/patch-package) and it's working fine, but it not the right fix. However, there's no "correct" handling available for any OS/arch combinations not supported by Traveling Ruby currently, so I'm submitting this anyway. :)