### PR TITLE
feat: expose faiIfNoPactsFound on the VerifierOptions

### DIFF
--- a/native/addon.cc
+++ b/native/addon.cc
@@ -57,6 +57,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set(Napi::String::New(env, "pactffiVerifierSetFilterInfo"), Napi::Function::New(env, PactffiVerifierSetFilterInfo));
   exports.Set(Napi::String::New(env, "pactffiVerifierSetProviderState"), Napi::Function::New(env, PactffiVerifierSetProviderState));
   exports.Set(Napi::String::New(env, "pactffiVerifierSetConsumerFilters"), Napi::Function::New(env, PactffiVerifierSetConsumerFilters));
+  exports.Set(Napi::String::New(env, "pactffiVerifierSetFailIfNoPactsFound"), Napi::Function::New(env, PactffiVerifierSetFailIfNoPactsFound));
   exports.Set(Napi::String::New(env, "pactffiVerifierAddCustomHeader"), Napi::Function::New(env, PactffiVerifierAddCustomHeader));
   exports.Set(Napi::String::New(env, "pactffiVerifierAddFileSource"), Napi::Function::New(env, PactffiVerifierAddFileSource));
   exports.Set(Napi::String::New(env, "pactffiVerifierAddDirectorySource"), Napi::Function::New(env, PactffiVerifierAddDirectorySource));

--- a/native/provider.cc
+++ b/native/provider.cc
@@ -464,6 +464,39 @@ Napi::Value PactffiVerifierSetConsumerFilters(const Napi::CallbackInfo& info) {
   return info.Env().Undefined();
 }
 
+
+/**
+ * Set the provider to fail or pass if no pacts can be found.
+ *
+ * C interface:
+ *
+ *     void pactffi_verifier_set_no_pacts_is_error(VerifierHandle *handle,
+ *                                                 unsigned char is_error);
+ *
+ */
+Napi::Value PactffiVerifierSetFailIfNoPactsFound(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 2) {
+    throw Napi::Error::New(env, "PactffiVerifierSetFailIfNoPactsFound received < 2 arguments");
+  }
+
+  if (!info[0].IsNumber()) {
+    throw Napi::Error::New(env, "pactffiVerifierSetFailIfNoPactsFound(arg 0) expected a VerifierHandle");
+  }
+
+  if (!info[1].IsBoolean()) {
+    throw Napi::Error::New(env, "pactffiVerifierSetFailIfNoPactsFound(arg 1) expected a boolean");
+  }
+
+  uint32_t handleId = info[0].As<Napi::Number>().Uint32Value();
+  bool failIfNoPactsFound = info[1].As<Napi::Boolean>().Value();
+
+  pactffi_verifier_set_no_pacts_is_error(handles[handleId], failIfNoPactsFound);
+
+  return info.Env().Undefined();
+}
+
+
 /**
  * Adds a custom header to be added to the requests made to the provider.
  *

--- a/native/provider.h
+++ b/native/provider.h
@@ -15,6 +15,7 @@ Napi::Value PactffiVerifierAddDirectorySource(const Napi::CallbackInfo& info);
 Napi::Value PactffiVerifierUrlSource(const Napi::CallbackInfo& info);
 // Napi::Value PactffiVerifierBrokerSource(const Napi::CallbackInfo& info);
 Napi::Value PactffiVerifierBrokerSourceWithSelectors(const Napi::CallbackInfo& info);
+Napi::Value PactffiVerifierSetFailIfNoPactsFound(const Napi::CallbackInfo& info);
 // Unimplemented
 // Napi::Value PactffiVerifierShutdown(const Napi::CallbackInfo& info);
 // Napi::Value PactffiVerifierNewForApplication(const Napi::CallbackInfo& info);

--- a/src/ffi/types.ts
+++ b/src/ffi/types.ts
@@ -320,6 +320,10 @@ export type FfiVerificationFunctions = {
     handle: FfiVerifierHandle,
     consumers: string[]
   ): void;
+  pactffiVerifierSetFailIfNoPactsFound(
+    handle: FfiVerifierHandle,
+    failIfNoPactsFound: boolean
+  ): void;
   pactffiVerifierAddCustomHeader(
     handle: FfiVerifierHandle,
     header: string,

--- a/src/verifier/argumentMapper/arguments.ts
+++ b/src/verifier/argumentMapper/arguments.ts
@@ -31,9 +31,10 @@ export const orderOfExecution: OrderedExecution = {
   pactffiVerifierSetVerificationOptions: 4,
   pactffiVerifierSetPublishOptions: 5,
   pactffiVerifierSetConsumerFilters: 6,
-  pactffiVerifierAddCustomHeader: 7,
-  pactffiVerifierAddDirectorySource: 8,
-  pactffiVerifierBrokerSourceWithSelectors: 9,
+  pactffiVerifierSetFailIfNoPactsFound: 7,
+  pactffiVerifierAddCustomHeader: 8,
+  pactffiVerifierAddDirectorySource: 9,
+  pactffiVerifierBrokerSourceWithSelectors: 10,
 };
 
 export type MergedFfiSourceFunctions = {
@@ -172,6 +173,18 @@ export const ffiFnMapping: FnMapping<
     validateAndExecute(ffi, handle, options) {
       if (options.consumerFilters && options.consumerFilters.length > 0) {
         ffi.pactffiVerifierSetConsumerFilters(handle, options.consumerFilters);
+        return { status: FnValidationStatus.SUCCESS };
+      }
+      return { status: FnValidationStatus.IGNORE };
+    },
+  },
+  pactffiVerifierSetFailIfNoPactsFound: {
+    validateAndExecute(ffi, handle, options) {
+      if (options.failIfNoPactsFound) {
+        ffi.pactffiVerifierSetFailIfNoPactsFound(
+          handle,
+          options.failIfNoPactsFound
+        );
         return { status: FnValidationStatus.SUCCESS };
       }
       return { status: FnValidationStatus.IGNORE };

--- a/src/verifier/types.ts
+++ b/src/verifier/types.ts
@@ -47,6 +47,7 @@ export interface VerifierOptions {
    * @deprecated use providerVersionBranch instead
    */
   providerBranch?: string;
+  failIfNoPactsFound?: boolean;
 }
 
 /** These are the deprecated verifier options, removed prior to this verison,

--- a/src/verifier/validateOptions.ts
+++ b/src/verifier/validateOptions.ts
@@ -243,6 +243,7 @@ export const validationRules: ArgumentValidationRules<InternalPactVerifierOption
     monkeypatch: [deprecatedFunction],
     logDir: [deprecatedFunction],
     consumerFilters: [wrapCheckType(checkTypes.assert.nonEmptyString)],
+    failIfNoPactsFound: [wrapCheckType(checkTypes.assert.boolean)],
   };
 
 export const validateOptions = (options: VerifierOptions): VerifierOptions => {


### PR DESCRIPTION
This PR is to add in the ability for Providers to specify if they want to pass or fail when no pacts can be found to verify.

Fixes (pact-foundation/pact-js#941)
