### PR TITLE
Avoid (some) type related bugs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,38 +1,45 @@
 {
-	"parser": "@typescript-eslint/parser",
-	"extends": [
-		"plugin:@typescript-eslint/recommended"
-	],
-	"parserOptions": {
-		"ecmaVersion": 2018,
-		"sourceType": "module"
-	},
-	"rules": {
-		"curly": 2,
-		"indent": 0,
-		"no-console": 0,
-		"max-len": [
-			2,
-			{
-				"code": 200
-			}
-		],
-		"trailing-comma": 0,
-		"object-literal-sort-keys": 0,
-		"no-reference": 0,
-		"no-trailing-whitespace": 0,
-		"typedef-whitespace": 0,
-		"whitespace": 0,
-		"interface-name": 0,
-		"ordered-imports": 0,
-		"variable-name": 0,
-		"no-var-requires": 0,
-		"object-literal-shorthand": 0,
-		"no-empty": 0,
-		"max-classes-per-file": 0,
-		"prefer-const": 0,
-		"no-unused-expression": 0,
-		"forin": 0,
-		"object-literal-key-quotes": 0
-	}
+  "parser": "@typescript-eslint/parser",
+  "extends": ["plugin:@typescript-eslint/recommended"],
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "curly": 2,
+    "indent": 0,
+    "no-console": 0,
+    "max-len": [
+      2,
+      {
+        "code": 200
+      }
+    ],
+    "@typescript-eslint/no-explicit-any": "error",
+    "trailing-comma": 0,
+    "object-literal-sort-keys": 0,
+    "no-reference": 0,
+    "no-trailing-whitespace": 0,
+    "typedef-whitespace": 0,
+    "whitespace": 0,
+    "interface-name": 0,
+    "ordered-imports": 0,
+    "variable-name": 0,
+    "no-var-requires": 0,
+    "object-literal-shorthand": 0,
+    "no-empty": 0,
+    "max-classes-per-file": 0,
+    "prefer-const": 0,
+    "no-unused-expression": 0,
+    "forin": 0,
+    "object-literal-key-quotes": 0
+  },
+  "overrides": [
+    {
+      "files": ["*.spec.ts"],
+      "rules": {
+        "@typescript-eslint/no-explicit-any": "off"
+      }
+    }
+  ]
 }

--- a/src/verifier/argumentMapper/arguments.ts
+++ b/src/verifier/argumentMapper/arguments.ts
@@ -14,13 +14,23 @@ const objArrayToStringArray = (obj: unknown[]) => {
   return obj.map((o) => JSON.stringify(o));
 };
 
-export type IgnoredFfiFunctions = {
+type IgnoredFfiFunctions = {
   pactffiVerifierNewForApplication: 1;
   pactffiVerifierExecute: 1;
   pactffiVerifierShutdown: 1;
 };
 
-export type OrderedExecution = {
+type MergedFfiSourceFunctions = {
+  pactffiVerifierAddFileSource: 1;
+  pactffiVerifierUrlSource: 1;
+};
+
+type RequiredFfiVerificationFunctions = Omit<
+  FfiVerificationFunctions,
+  keyof (IgnoredFfiFunctions & MergedFfiSourceFunctions)
+>;
+
+type OrderedExecution = {
   [Key in keyof RequiredFfiVerificationFunctions]: number;
 };
 
@@ -36,16 +46,6 @@ export const orderOfExecution: OrderedExecution = {
   pactffiVerifierAddDirectorySource: 9,
   pactffiVerifierBrokerSourceWithSelectors: 10,
 };
-
-export type MergedFfiSourceFunctions = {
-  pactffiVerifierAddFileSource: 1;
-  pactffiVerifierUrlSource: 1;
-};
-
-export type RequiredFfiVerificationFunctions = Omit<
-  FfiVerificationFunctions,
-  keyof (IgnoredFfiFunctions & MergedFfiSourceFunctions)
->;
 
 export const ffiFnMapping: FnMapping<
   RequiredFfiVerificationFunctions,

--- a/src/verifier/argumentMapper/arguments.ts
+++ b/src/verifier/argumentMapper/arguments.ts
@@ -77,13 +77,16 @@ export const ffiFnMapping: FnMapping<
           }
         }
         if (messages.length > 0) {
-          return { status: FnValidationStatus.FAIL };
+          return { status: FnValidationStatus.FAIL, messages };
         }
 
         return { status: FnValidationStatus.SUCCESS };
       }
 
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: ['No customProviderHeaders option provided'],
+      };
     },
   },
   pactffiVerifierAddDirectorySource: {
@@ -141,7 +144,10 @@ export const ffiFnMapping: FnMapping<
         return { status: FnValidationStatus.SUCCESS };
       }
 
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: ['No pactUrls option provided'],
+      };
     },
   },
   pactffiVerifierBrokerSourceWithSelectors: {
@@ -166,7 +172,12 @@ export const ffiFnMapping: FnMapping<
         );
         return { status: FnValidationStatus.SUCCESS };
       }
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: [
+          'No pactBrokerUrl option / PACT_BROKER_BASE_URL set, or no provider option set',
+        ],
+      };
     },
   },
   pactffiVerifierSetConsumerFilters: {
@@ -175,7 +186,12 @@ export const ffiFnMapping: FnMapping<
         ffi.pactffiVerifierSetConsumerFilters(handle, options.consumerFilters);
         return { status: FnValidationStatus.SUCCESS };
       }
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: [
+          'Either no consumerFilters option provided, or the array was empty',
+        ],
+      };
     },
   },
   pactffiVerifierSetFailIfNoPactsFound: {
@@ -187,7 +203,10 @@ export const ffiFnMapping: FnMapping<
         );
         return { status: FnValidationStatus.SUCCESS };
       }
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: ['No failIfNoPactsFound option provided'],
+      };
     },
   },
   pactffiVerifierSetFilterInfo: {
@@ -211,7 +230,12 @@ export const ffiFnMapping: FnMapping<
         return { status: FnValidationStatus.SUCCESS };
       }
 
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: [
+          'None of PACT_DESCRIPTION, PACT_PROVIDER_STATE or PACT_PROVIDER_NO_STATE were set in the environment',
+        ],
+      };
     },
   },
   pactffiVerifierSetProviderInfo: {
@@ -242,7 +266,10 @@ export const ffiFnMapping: FnMapping<
         return { status: FnValidationStatus.SUCCESS };
       }
 
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: ['No failIfNoPactsFound option provided'],
+      };
     },
   },
   pactffiVerifierSetPublishOptions: {
@@ -261,7 +288,12 @@ export const ffiFnMapping: FnMapping<
         );
         return { status: FnValidationStatus.SUCCESS };
       }
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: [
+          'No publishVerificationResult option / PACT_BROKER_PUBLISH_VERIFICATION_RESULTS set, or no providerVersion option',
+        ],
+      };
     },
   },
   pactffiVerifierSetVerificationOptions: {
@@ -275,7 +307,10 @@ export const ffiFnMapping: FnMapping<
         return { status: FnValidationStatus.SUCCESS };
       }
 
-      return { status: FnValidationStatus.IGNORE };
+      return {
+        status: FnValidationStatus.IGNORE,
+        messages: ['No disableSslVerification or timeout set'],
+      };
     },
   },
 };

--- a/src/verifier/argumentMapper/index.ts
+++ b/src/verifier/argumentMapper/index.ts
@@ -1,4 +1,4 @@
-import { FnValidationStatus } from './types';
+import { FnValidationResult, FnValidationStatus } from './types';
 import logger, { logCrashAndThrow, logErrorAndThrow } from '../../logger';
 import { InternalPactVerifierOptions } from '../types';
 import { ffiFnMapping, orderOfExecution } from './arguments';
@@ -15,7 +15,7 @@ export const setupVerification = (
 
   order.map((k) => {
     const fn = functionsToCall[k];
-    const validation = ffiFnMapping[fn].validateAndExecute(
+    const validation: FnValidationResult = ffiFnMapping[fn].validateAndExecute(
       ffi,
       handle,
       options
@@ -36,7 +36,9 @@ export const setupVerification = (
         break;
       default:
         logCrashAndThrow(
-          `the ffi function '${fn}' returned the following unrecognised validation signal: '${validation.status}'`
+          `the ffi function '${fn}' returned the following unrecognised validation signal: '${
+            (validation as FnValidationResult).status
+          }'`
         );
     }
   });

--- a/src/verifier/argumentMapper/index.ts
+++ b/src/verifier/argumentMapper/index.ts
@@ -24,16 +24,12 @@ export const setupVerification = (
     switch (validation.status) {
       case FnValidationStatus.FAIL:
         logErrorAndThrow(
-          `the required ffi function '${fn}' failed validation with errors: ${
-            validation.messages || [].join(',')
-          }`
+          `the required ffi function '${fn}' failed validation with errors: ${validation.messages}`
         );
         break;
       case FnValidationStatus.IGNORE:
         logger.debug(
-          `the optional ffi function '${fn}' was not executed as it had non-fatal validation errors: ${
-            validation.messages || [].join(',')
-          }`
+          `the optional ffi function '${fn}' was not executed as it had non-fatal validation errors: ${validation.messages}`
         );
         break;
       case FnValidationStatus.SUCCESS:

--- a/src/verifier/argumentMapper/types.ts
+++ b/src/verifier/argumentMapper/types.ts
@@ -1,17 +1,25 @@
 import logger from '../../logger';
+import { Ffi, FfiHandle } from '../../ffi/types';
 
-export const deprecatedFunction = (_: any, property: string): boolean => {
+export const deprecatedFunction = (_: unknown, property: string): boolean => {
   logger.warn(`${property} is deprecated and no longer has any effect`);
 
   return true;
 };
-import { Ffi, FfiHandle } from '../../ffi/types';
 
-export type FnObject = {
-  [key: string]: (...args: any) => any;
+type KeyedObject = {
+  [key: string]: unknown;
 };
 
-export type FnMapping<T extends FnObject, O> = {
+type FnArgumentMapping<O> = {
+  validateAndExecute: (
+    ffi: Ffi,
+    handle: FfiHandle,
+    options: O
+  ) => FnValidationResult;
+};
+
+export type FnMapping<T extends KeyedObject, O> = {
   [Key in keyof T]: FnArgumentMapping<O>;
 };
 
@@ -21,15 +29,7 @@ export enum FnValidationStatus {
   FAIL = 2,
 }
 
-export type FnValidationResult = {
+type FnValidationResult = {
   status: FnValidationStatus;
   messages?: string[];
-};
-
-export type FnArgumentMapping<O> = {
-  validateAndExecute: (
-    ffi: Ffi,
-    handle: FfiHandle,
-    options: O
-  ) => FnValidationResult;
 };

--- a/src/verifier/argumentMapper/types.ts
+++ b/src/verifier/argumentMapper/types.ts
@@ -29,7 +29,21 @@ export enum FnValidationStatus {
   FAIL = 2,
 }
 
-type FnValidationResult = {
-  status: FnValidationStatus;
-  messages?: string[];
+type FnValidationResultSuccess = {
+  status: FnValidationStatus.SUCCESS;
 };
+
+type FnValidationResultFail = {
+  status: FnValidationStatus.FAIL;
+  messages: string[];
+};
+
+type FnValidationResultIgnore = {
+  status: FnValidationStatus.IGNORE;
+  messages: string[];
+};
+
+export type FnValidationResult =
+  | FnValidationResultSuccess
+  | FnValidationResultFail
+  | FnValidationResultIgnore;


### PR DESCRIPTION
As discussed on slack, I've tidied up some types with the view to avoid bugs like the one raised in #general.

I've also uncovered some other things that are probably bugs - here's a list of what I did and did not fix:

## What changed

* Removed a `l = l.toLowerCase() as LogLevel;` that had no effect (**this was probably a bug**, but now the code doesn't look like it is lowercasing the log level when it isn't. **I did not fix the bug**)

### Type safety improvements

* Prevented use of `any` with an eslint rule and replaced the uses everywhere
    * This is because `any` just turns off type safety. You should not need to do this
* Replaced the AssertFunction type pattern with one that doesn't need to look inside the checkTypes library (this wasn't compiling when I removed the `any`, so it wasn't the right type anyway). 
    * I'm not sure what the wrapCheckTypes function was for - maybe just to make the compiler happy? It's gone now as it wasn't making the compiler happy once it was not just turning off the type safety.
* Removed the function from `FnObject` since the type was not correct and it was only being used for the keys (I renamed it `KeyedObject`).
    * I think four or so of these types can collapse down to one that just straight up does the mapping, maybe.  
* Made the type changes I mentioned on slack so that the `IGNORE` type must have `messages`
* I had to make a call as to whether "ignore" was supposed to have `messages` or not, since the calling code expected it to have them, but the called code expected it not to have them. I decided it was, and added some messages. The messages could be further improved by detecting the different cases and emitting more specific messages.

### Style things 

* Removed `export` from some types that weren't in `types.ts`. 
    * Only `types.ts` files are supposed to contain exported types. This pattern is a way of preventing circular imports, which can cause problems (although to be fair, they largely don't any more).
* Deleted some unused functions in `types.ts`  
    * Functions aren't supposed to be in `types.ts` anyway, as only types and the occasional constant are supposed to be in `types.ts`. But they weren't used, so they were safe to remove 
* Removed `export` from types that were in types.ts but weren't used outside it
    * This cleans up the exported interface and makes the code easier to read

### Complete personal preference things

* Reordered some types so they are at the top and in order of declaration need. 
    * This one is pure personal preference and only avoids the issue that I don't like it the other way <3
    
## Things I did not fix:

* There's a complete loss of type safety when this happens:

```
  const functionsToCall = invert(orderOfExecution);
```
This is because `invert` returns a type of `any`. To fix this, I would change this code to not need `invert`, and generally remove underscore - I don't think it plays well in TypeScript land (aside: I had to think of TypeScript as a completely different language - what was good style in JS is not necessarily good style in TS, and vice versa).  

I worked around it by setting a type later on with `const validation: FnValidationResult = ...` but the type safety issue is still there.

* I don't understand the organisation of the arguments code - for me, it has lost the clarity about what file does what. For example, `setupVerification` does validation, the arguments mapper knows a great deal about the FFI, and the validator also executes now? It all seems risky to me.
* Relatedly, I couldn't figure out where the removed `l = l.toLowerCase() as LogLevel` was supposed to have been, so I didn't fix that.
* `pactffiVerifierSetProviderInfo` doesn't fail if there's no `providerBaseUrl` - but it looks like it probably is supposed to.

-------

## The tests still fail

I ran the tests before and after this change, and the same one was failing:

```
  238 passing (57s)
  5 pending
  1 failing

  1) FFI integration test for the HTTP Consumer API
       with binary data
         generates a pact with success:
     Error: Request failed with status code 500
      at createError (node_modules/axios/lib/core/createError.js:16:15)
      at settle (node_modules/axios/lib/core/settle.js:17:12)
      at IncomingMessage.handleStreamEnd (node_modules/axios/lib/adapters/http.js:293:11)
      at IncomingMessage.emit (node:events:525:35)
      at IncomingMessage.emit (node:domain:489:12)
      at endReadableNT (node:internal/streams/readable:1359:12)
      at processTicksAndRejections (node:internal/process/task_queues:82:21)
```

I believe the failure is unrelated to this change.