### PR TITLE
fix: Update pact-ruby-standalone to 1.91.0, shortening the path for windows users

### DIFF
--- a/standalone/install.ts
+++ b/standalone/install.ts
@@ -25,7 +25,7 @@ if (environmentProxy) {
 }
 
 // Get latest version from https://github.com/pact-foundation/pact-ruby-standalone/releases
-export const PACT_STANDALONE_VERSION = '1.89.02-rc1';
+export const PACT_STANDALONE_VERSION = '1.91.0';
 const PACT_DEFAULT_LOCATION = `https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_STANDALONE_VERSION}/`;
 const HTTP_REGEX = /^http(s?):\/\//;
 


### PR DESCRIPTION
I'm not sure if pact-node is still being released, but this addresses [the regression](https://pact-foundation.slack.com/archives/C9VPNUJR2/p1669678385756549?thread_ts=1669658751.887949&cid=C9VPNUJR2) introduced in 10.17.3 - by updating the version to the main release instead of release candidate releases (which have longer version numbers, and are more likely to hit the long path issue)