### PR TITLE
feat: add pactffi_log_to_file for consumer/verifier

### DIFF
--- a/native/addon.cc
+++ b/native/addon.cc
@@ -8,6 +8,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set(Napi::String::New(env, "pactffiVersion"), Napi::Function::New(env, PactffiVersion));
   exports.Set(Napi::String::New(env, "pactffiInit"), Napi::Function::New(env, PactffiInit));
   exports.Set(Napi::String::New(env, "pactffiInitWithLogLevel"), Napi::Function::New(env, PactffiInitWithLogLevel));
+  exports.Set(Napi::String::New(env, "pactffiLogToFile"), Napi::Function::New(env, PactffiLogToFile));
 
   // Consumer
   exports.Set(Napi::String::New(env, "pactffiMockServerMatched"), Napi::Function::New(env, PactffiMockServerMatched));

--- a/native/ffi.cc
+++ b/native/ffi.cc
@@ -49,6 +49,64 @@ Napi::Value PactffiInitWithLogLevel(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+LevelFilter integerToLevelFilter(Napi::Env &env, uint32_t number) {
+  LevelFilter logLevel = LevelFilter::LevelFilter_Off;
+
+  switch(number) {
+    case 0:
+      logLevel = LevelFilter::LevelFilter_Off;
+      break;
+    case 1:
+      logLevel = LevelFilter::LevelFilter_Error;
+      break;
+    case 2:
+      logLevel = LevelFilter::LevelFilter_Warn;
+      break;
+    case 3:
+      logLevel = LevelFilter::LevelFilter_Info;
+      break;
+    case 4:
+      logLevel = LevelFilter::LevelFilter_Debug;
+      break;
+    case 5:
+      logLevel = LevelFilter::LevelFilter_Trace;
+      break;
+    default:
+      std::string err =  "pact-js-core C integration: Unable to parse log level number: ";
+      err += number;
+
+      throw Napi::Error::New(env, err);
+  }
+
+  return logLevel;
+}
+
+
+Napi::Value PactffiLogToFile(const Napi::CallbackInfo& info) {
+   // return: int
+   Napi::Env env = info.Env();
+
+  if (info.Length() < 2) {
+    throw Napi::Error::New(env, "PactffiLogToFile(envVar) received < 2 arguments");
+  }
+
+    if (!info[0].IsString()) {
+    throw Napi::Error::New(env, "PactffiLogToFile(envVar) expected a string");
+  }
+
+  if (!info[1].IsNumber()) {
+    throw Napi::Error::New(env, "PactffiLogToFile(envVar) expected a number");
+  }
+
+  // Extract log level
+  std::string fileName = info[0].As<Napi::String>().Utf8Value();
+  uint32_t levelFilterNumber = info[1].As<Napi::Number>().Uint32Value();
+  LevelFilter levelFilter = integerToLevelFilter(env, levelFilterNumber);
+
+  int res = pactffi_log_to_file(fileName.c_str(), levelFilter);
+
+  return Napi::Number::New(env, res);
+}
 /*
 
 Napi::Value Pactffi_log_message(const Napi::CallbackInfo& info) {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "build": "tsc --project tsconfig.build.json",
     "prerelease": "npm run snyk-protect",
     "release": "commit-and-tag-version",
-    "test": "cross-env LOGLEVEL=debug PACT_DO_NOT_TRACK=true mocha \"{src,test}/**/*.spec.ts\"",
+    "test": "cross-env PACT_DO_NOT_TRACK=true mocha \"{src,test}/**/*.spec.ts\"",
     "snyk-protect": "snyk-protect",
     "format:base": "prettier --parser typescript",
     "format:check": "npm run format:base -- --list-different \"{src,test}/**/*.{ts,tsx}\"",

--- a/src/consumer/index.ts
+++ b/src/consumer/index.ts
@@ -62,12 +62,13 @@ export const makeConsumerPact = (
   consumer: string,
   provider: string,
   version: FfiSpecificationVersion = 3,
-  logLevel = getLogLevel()
+  logLevel = getLogLevel(),
+  logFile?: string
 ): ConsumerPact => {
-  const ffi = getFfiLib(logLevel);
   if (logLevel) {
     setLogLevel(logLevel);
   }
+  const ffi = getFfiLib(logLevel, logFile);
 
   const pactPtr = ffi.pactffiNewPact(consumer, provider);
   if (!ffi.pactffiWithSpecification(pactPtr, version)) {
@@ -370,12 +371,13 @@ export const makeConsumerMessagePact = (
   consumer: string,
   provider: string,
   version: FfiSpecificationVersion = 4,
-  logLevel = getLogLevel()
+  logLevel = getLogLevel(),
+  logFile?: string
 ): ConsumerMessagePact => {
-  const ffi = getFfiLib(logLevel);
   if (logLevel) {
     setLogLevel(logLevel);
   }
+  const ffi = getFfiLib(logLevel, logFile);
 
   const pactPtr = ffi.pactffiNewPact(consumer, provider);
   if (!ffi.pactffiWithSpecification(pactPtr, version) || version < 4) {

--- a/src/verifier/nativeVerifier.ts
+++ b/src/verifier/nativeVerifier.ts
@@ -14,7 +14,7 @@ export const verify = (opts: VerifierOptions): Promise<string> => {
   if (opts.logLevel) {
     setLogLevel(opts.logLevel);
   }
-  const ffi = getFfiLib(opts.logLevel);
+  const ffi = getFfiLib(opts.logLevel, opts.logFile);
 
   const handle = ffi.pactffiVerifierNewForApplication(
     pkg.name.split('/')[1],

--- a/src/verifier/types.ts
+++ b/src/verifier/types.ts
@@ -46,6 +46,7 @@ export interface VerifierOptions {
   consumerVersionSelectors?: ConsumerVersionSelector[];
   timeout?: number;
   logLevel?: LogLevel;
+  logFile?: string;
   disableSslVerification?: boolean;
   buildUrl?: string;
   customProviderHeaders?: CustomHeaders | string[];

--- a/src/verifier/validateOptions.ts
+++ b/src/verifier/validateOptions.ts
@@ -247,6 +247,7 @@ export const validationRules: ArgumentValidationRules<InternalPactVerifierOption
     verbose: [deprecatedFunction],
     monkeypatch: [deprecatedFunction],
     logDir: [deprecatedFunction],
+    logFile: [assertNonEmptyString],
     consumerFilters: [assertNonEmptyString],
     failIfNoPactsFound: [assertBoolean],
     transports: [],

--- a/test/consumer.integration.spec.ts
+++ b/test/consumer.integration.spec.ts
@@ -7,7 +7,6 @@ import zlib = require('zlib');
 import FormData = require('form-data');
 import fs = require('fs');
 import { load } from 'protobufjs';
-import { setLogLevel } from '../src/logger';
 import {
   ConsumerPact,
   makeConsumerPact,
@@ -21,8 +20,6 @@ const { expect } = chai;
 const HOST = '127.0.0.1';
 
 describe('FFI integration test for the HTTP Consumer API', () => {
-  setLogLevel('trace');
-
   let port: number;
   let pact: ConsumerPact;
   const bytes: Buffer = zlib.gzipSync('this is an encoded string');

--- a/test/matt.consumer.integration.spec.ts
+++ b/test/matt.consumer.integration.spec.ts
@@ -9,7 +9,6 @@ import {
   makeConsumerMessagePact,
   makeConsumerPact,
 } from '../src';
-import { setLogLevel } from '../src/logger';
 import { FfiSpecificationVersion } from '../src/ffi/types';
 
 chai.use(chaiAsPromised);
@@ -45,8 +44,6 @@ const sendMattMessageTCP = (
 
 const skipPluginTests = process.env['SKIP_PLUGIN_TESTS'] === 'true';
 (skipPluginTests ? describe.skip : describe)('MATT protocol test', () => {
-  setLogLevel('trace');
-
   let provider: ConsumerPact;
   let tcpProvider: ConsumerMessagePact;
   let port: number;


### PR DESCRIPTION
# Add ability to log to file, via pactffi_log_to_file

Will go someway to address https://github.com/pact-foundation/pact-js/issues/954

(will need adding into pact-js)

Passed in via an optional param, to `getFfiLib` which is called by a couple of functions, as an optional param. Wonder if it would be better to have these in an opts object that can take named params.

note, the option used to be called `log` in pact-js v2 and is moved to deprecated now. should we retain `log` or use a more descriptive `logFile`

https://github.com/pact-foundaton/pact-js/tree/9.x.x#constructor

## edit

need to add some appropriate tests and refactor based on review comments :)