### PR TITLE
fix: Fix an issue where invalid VerifierOptions keys with Array values would cause a TypeError

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set MSVS version
-        run: npm config set msvs_version 2017
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Set MSVS version
+        run: npm config set msvs_version 2017
       - run: script/ci/build-and-test.sh
         env:
           NODE_VERSION: ${{ matrix.node-version }}

--- a/src/verifier/validateOptions.spec.ts
+++ b/src/verifier/validateOptions.spec.ts
@@ -47,6 +47,18 @@ describe('Verifier argument validator', () => {
         });
       });
     });
+
+    context('when given an unknown array argument', () => {
+      it('should return a Verifier object', () => {
+        expectSuccessWith({
+          madeupArg: [''],
+          providerBaseUrl: 'http://localhost',
+          pactBrokerUrl: 'http://foo.com',
+          pactUrls: ['http://idontexist'],
+          provider: 'someprovider',
+        } as VerifierOptions);
+      });
+    });
   });
 
   context('when not given --pact-urls or --provider-base-url', () => {

--- a/src/verifier/validateOptions.ts
+++ b/src/verifier/validateOptions.ts
@@ -263,7 +263,7 @@ export const validateOptions = (options: VerifierOptions): VerifierOptions => {
     // get type of parameter (if an array, we apply the rule to each item of the array instead)
     if (Array.isArray(options[k])) {
       options[k].forEach((item: unknown) => {
-        rules.forEach((rule) => {
+        (rules || []).forEach((rule) => {
           // rule(item)  // If the messages aren't clear, we can do this
           rule(options)(item, k);
         });


### PR DESCRIPTION
### PR Template

This PR fixes an issue raised by [Gustavo Souza on slack here](https://pact-foundation.slack.com/archives/C9VBGLUM9/p1678279738564239), where an unknown key with an array value would cause the Verifier validation to fail with `cannot read property forEach of undefined`.

It also adds a test for this case.

The test also passes.
