### PR TITLE
fix: Use synchronous logging to allow usage with Jest

### DIFF
--- a/src/logger/pino.ts
+++ b/src/logger/pino.ts
@@ -1,10 +1,8 @@
 import { pino } from 'pino';
+import pretty from 'pino-pretty';
 import { LogLevel } from './types';
 
 export const createLogger = (level: LogLevel): pino.Logger =>
   pino({
     level: level.toLowerCase(),
-    transport: {
-      target: 'pino-pretty',
-    },
-  });
+  }, pretty({ sync: true }));

--- a/src/logger/pino.ts
+++ b/src/logger/pino.ts
@@ -3,6 +3,9 @@ import pretty from 'pino-pretty';
 import { LogLevel } from './types';
 
 export const createLogger = (level: LogLevel): pino.Logger =>
-  pino({
-    level: level.toLowerCase(),
-  }, pretty({ sync: true }));
+  pino(
+    {
+      level: level.toLowerCase(),
+    },
+    pretty({ sync: true })
+  );


### PR DESCRIPTION
See: https://github.com/pinojs/pino-pretty#usage-with-jest

NB: This introduces a performance regression, but probably acceptable given this is a dev-only tool.

This seem to fix the issue showcased in https://github.com/Maxim-Filimonov/pact-js-jest-memory-leak-example. However, I'm slightly confused by `pino-pretty` - my logs don't even look pretty at all!