### PR TITLE
fix: Remove unusable external export of HTTPConfig which removes the need to have needle types as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "win32"
       ],
       "dependencies": {
-        "@types/needle": "2.5.2",
         "bindings": "^1.5.0",
         "chalk": "4.1.2",
         "check-types": "7.3.0",
@@ -60,6 +59,7 @@
         "@types/express": "4.11.1",
         "@types/mkdirp": "^0.5.2",
         "@types/mocha": "9.0.0",
+        "@types/needle": "2.5.2",
         "@types/node": "^18.11.10",
         "@types/promise-timeout": "^1.3.0",
         "@types/rimraf": "^2.0.2",
@@ -766,6 +766,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@types/needle/-/needle-2.5.2.tgz",
       "integrity": "sha512-FSckojxsXODVYE4oJ7q0OjUki27a6gsdIxp2WJHs9oEmXit/0rjzb/NK+tJnKwFMMyR6mzo+1Nyr83ELw3YT+Q==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -773,7 +774,8 @@
     "node_modules/@types/node": {
       "version": "18.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -8221,6 +8223,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/@types/needle/-/needle-2.5.2.tgz",
       "integrity": "sha512-FSckojxsXODVYE4oJ7q0OjUki27a6gsdIxp2WJHs9oEmXit/0rjzb/NK+tJnKwFMMyR6mzo+1Nyr83ELw3YT+Q==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -8228,7 +8231,8 @@
     "@types/node": {
       "version": "18.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/needle": "2.5.2",
     "bindings": "^1.5.0",
     "chalk": "4.1.2",
     "check-types": "7.3.0",
@@ -83,6 +82,7 @@
     "@types/express": "4.11.1",
     "@types/mkdirp": "^0.5.2",
     "@types/mocha": "9.0.0",
+    "@types/needle": "2.5.2",
     "@types/node": "^18.11.10",
     "@types/promise-timeout": "^1.3.0",
     "@types/rimraf": "^2.0.2",

--- a/src/service.ts
+++ b/src/service.ts
@@ -11,7 +11,7 @@ import needle = require('needle');
 import spawn, { CliVerbOptions } from './spawn';
 import { LogLevel } from './logger/types';
 import logger, { setLogLevel } from './logger';
-import { HTTPConfig, ServiceOptions } from './types';
+import { ServiceOptions } from './types';
 
 // Get a reference to the global setTimeout object in case it is mocked by a testing library later
 const { setTimeout } = global;
@@ -320,7 +320,7 @@ export abstract class AbstractService extends events.EventEmitter {
   }
 
   private __call(options: ServiceOptions): Promise<unknown> {
-    const config: HTTPConfig = {
+    const config: needle.NeedleOptions = {
       method: 'GET',
       headers: {
         'X-Pact-Mock-Service': 'true',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-import needle from 'needle';
 import { LogLevel } from './logger/types';
 
 export interface MessageOptions {
@@ -35,11 +34,4 @@ export interface ServiceOptions {
   log?: string;
   logLevel?: LogLevel;
   timeout?: number;
-}
-
-export interface HTTPConfig extends Omit<needle.NeedleOptions, 'headers'> {
-  headers: {
-    'X-Pact-Mock-Service': string;
-    'Content-Type': string;
-  };
 }


### PR DESCRIPTION
https://github.com/pact-foundation/jest-pact/pull/221 failed the build because of the way that Pact-JS-Core imports the needle type for re-export.

When I looked in to this, I saw that the needle type wasn't usable outside Pact-JS-Core (you wouldn't need it, and it can't be passed in). I don't think it was meant to be exported.

This PR fixes that by removing the custom `HTTPConfig` type entirely, since it wasn't really necessary (I'm not actually sure why it was there - perhaps I am missing something). 

It also moves the `@types/needle` dependency back to devDependencies.