### PR TITLE
CI: Test across Node 16/18/20 + arm64 MacOS test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,8 @@ mac_task:
       - NODE_VERSION: 16
       - NODE_VERSION: 18
       - NODE_VERSION: 20
-  install_script:
+  install_script: # we need to install rosetta as v1.x of pact-ruby-standalone doesn't support arm64
+    - softwareupdate --install-rosetta --agree-to-license
     - brew install nvm
     - source $(brew --prefix nvm)/nvm.sh
     - nvm install $NODE_VERSION

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,6 @@ BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
 #   << : *BUILD_TEST_TASK_TEMPLATE
 
 linux_amd64_task:
-  skip: "changesInclude('.github/**')" 
   env:
     matrix:
       - IMAGE: node:16-slim
@@ -40,7 +39,6 @@ linux_amd64_task:
 
 
 mac_task:
-  skip: "changesInclude('.github/**')" 
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,58 @@
+env:
+  PACT_BROKER_FEATURES: publish_pacts_using_old_api
+
+BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
+  arch_check_script:
+    - uname -am
+  test_script:
+    - node --version
+    - script/ci/build-and-test.sh
+
+# These are probably expected to fail in the post install script
+# until we are packing v2.0.0 of pact-ruby-standalone that supports
+# arm64 linux
+linux_arm64_task:
+  skip: "!changesInclude('.github/**')" 
+  env:
+    matrix:
+      - IMAGE: node:16-slim
+      - IMAGE: node:18-slim
+      - IMAGE: node:20-slim
+  arm_container:
+    image: $IMAGE
+  install_script:
+    - apt update --yes && apt install --yes curl python3 make build-essential g++
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+linux_amd64_task:
+  skip: "!changesInclude('.github/**')" 
+  env:
+    matrix:
+      - IMAGE: node:16-slim
+      - IMAGE: node:18-slim
+      - IMAGE: node:20-slim
+  container:
+    image: $IMAGE
+  install_script:
+    - apt update --yes && apt install --yes curl python3 make build-essential g++
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+
+mac_task:
+  skip: "!changesInclude('.github/**')" 
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  env:
+    PACT_BROKER_FEATURES: publish_pacts_using_old_api
+    NVS_HOME: ${HOME}/.nvs
+    PATH: ${NVS_HOME}:${PATH}
+    matrix:
+      - NODE_VERSION: 16
+      - NODE_VERSION: 18
+      - NODE_VERSION: 20
+  install_script:
+    - brew install nvm
+    - source $(brew --prefix nvm)/nvm.sh
+    - nvm install $NODE_VERSION
+    - nvm use $NODE_VERSION
+  << : *BUILD_TEST_TASK_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
 # until we are packing v2.0.0 of pact-ruby-standalone that supports
 # arm64 linux
 linux_arm64_task:
-  skip: "!changesInclude('.github/**')" 
+  skip: "changesInclude('.github/**')" 
   env:
     matrix:
       - IMAGE: node:16-slim
@@ -25,7 +25,7 @@ linux_arm64_task:
   << : *BUILD_TEST_TASK_TEMPLATE
 
 linux_amd64_task:
-  skip: "!changesInclude('.github/**')" 
+  skip: "changesInclude('.github/**')" 
   env:
     matrix:
       - IMAGE: node:16-slim

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ linux_arm64_task:
   arm_container:
     image: $IMAGE
   install_script:
-    - apt update --yes && apt install --yes curl python3 make build-essential g++
+    - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
   << : *BUILD_TEST_TASK_TEMPLATE
 
 linux_amd64_task:
@@ -34,12 +34,12 @@ linux_amd64_task:
   container:
     image: $IMAGE
   install_script:
-    - apt update --yes && apt install --yes curl python3 make build-essential g++
+    - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
   << : *BUILD_TEST_TASK_TEMPLATE
 
 
 mac_task:
-  skip: "!changesInclude('.github/**')" 
+  skip: "changesInclude('.github/**')" 
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,18 +25,18 @@ BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
 #     - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
 #   << : *BUILD_TEST_TASK_TEMPLATE
 
-# linux_amd64_task:
-#   skip: "changesInclude('.github/**')" 
-#   env:
-#     matrix:
-#       - IMAGE: node:16-slim
-#       - IMAGE: node:18-slim
-#       - IMAGE: node:20-slim
-#   container:
-#     image: $IMAGE
-#   install_script:
-#     - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
-#   << : *BUILD_TEST_TASK_TEMPLATE
+linux_amd64_task:
+  skip: "changesInclude('.github/**')" 
+  env:
+    matrix:
+      - IMAGE: node:16-slim
+      - IMAGE: node:18-slim
+      - IMAGE: node:20-slim
+  container:
+    image: $IMAGE
+  install_script:
+    - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
+  << : *BUILD_TEST_TASK_TEMPLATE
 
 
 mac_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,32 +10,33 @@ BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
 
 # These are probably expected to fail in the post install script
 # until we are packing v2.0.0 of pact-ruby-standalone that supports
-# arm64 linux
-linux_arm64_task:
-  skip: "changesInclude('.github/**')" 
-  env:
-    matrix:
-      - IMAGE: node:16-slim
-      - IMAGE: node:18-slim
-      - IMAGE: node:20-slim
-  arm_container:
-    image: $IMAGE
-  install_script:
-    - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
-  << : *BUILD_TEST_TASK_TEMPLATE
+# arm64 linux - as per https://github.com/pact-foundation/pact-js-core/issues/416
+# Error: Error while locating pact binary: Cannot find binary for platform 'linux' with architecture 'arm64'.
+# linux_arm64_task:
+#   skip: "changesInclude('.github/**')" 
+#   env:
+#     matrix:
+#       - IMAGE: node:16-slim
+#       - IMAGE: node:18-slim
+#       - IMAGE: node:20-slim
+#   arm_container:
+#     image: $IMAGE
+#   install_script:
+#     - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
+#   << : *BUILD_TEST_TASK_TEMPLATE
 
-linux_amd64_task:
-  skip: "changesInclude('.github/**')" 
-  env:
-    matrix:
-      - IMAGE: node:16-slim
-      - IMAGE: node:18-slim
-      - IMAGE: node:20-slim
-  container:
-    image: $IMAGE
-  install_script:
-    - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
-  << : *BUILD_TEST_TASK_TEMPLATE
+# linux_amd64_task:
+#   skip: "changesInclude('.github/**')" 
+#   env:
+#     matrix:
+#       - IMAGE: node:16-slim
+#       - IMAGE: node:18-slim
+#       - IMAGE: node:20-slim
+#   container:
+#     image: $IMAGE
+#   install_script:
+#     - apt update --yes && apt install --yes curl python3 make build-essential g++ unzip zip
+#   << : *BUILD_TEST_TASK_TEMPLATE
 
 
 mac_task:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,30 +25,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: script/ci/build-and-test.sh
-        if: runner != 'Windows'
-        env:
-          NODE_VERSION: ${{ matrix.node-version }}
-          PACT_BROKER_FEATURES: publish_pacts_using_old_api
-      - run: script/ci/build-and-test.sh
-        if: runner == 'Windows'
-        env:
-          NODE_VERSION: ${{ matrix.node-version }}
-          PACT_BROKER_FEATURES: publish_pacts_using_old_api
-          ONLY_DOWNLOAD_PACT_FOR_WINDOWS: true
-
-      - name: Set MSVS version
-        run: npm config set msvs_version 2017
-      - run: script/ci/build-and-test.sh
         if: runner.os != 'Windows'
         env:
           NODE_VERSION: ${{ matrix.node-version }}
           PACT_BROKER_FEATURES: publish_pacts_using_old_api
       - run: script/ci/build-and-test.sh
         if: runner.os == 'Windows'
-        # The windows build agent has trouble unpacking the tar for
-        # linux, so we only download windows binaries. This means
-        # we cannot release from Windows in CI.
-        # maybe we just need to install gunzip?
         env:
           NODE_VERSION: ${{ matrix.node-version }}
           PACT_BROKER_FEATURES: publish_pacts_using_old_api

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,64 +8,46 @@ on:
 
 jobs:
   build-and-test-osx:
-    runs-on: macos-latest
+    runs-on: [macos-latest,ubuntu-latest,windows-latest]
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16,18,20]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: script/ci/build-and-test.sh
+        if: runner != 'Windows'
         env:
           NODE_VERSION: ${{ matrix.node-version }}
           PACT_BROKER_FEATURES: publish_pacts_using_old_api
+      - run: script/ci/build-and-test.sh
+        if: runner == 'Windows'
+        env:
+          NODE_VERSION: ${{ matrix.node-version }}
+          PACT_BROKER_FEATURES: publish_pacts_using_old_api
+          ONLY_DOWNLOAD_PACT_FOR_WINDOWS: true
 
-  build-and-test-ubuntu:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - name: Set MSVS version
         run: npm config set msvs_version 2017
       - run: script/ci/build-and-test.sh
+        if: runner != 'Windows'
         env:
           NODE_VERSION: ${{ matrix.node-version }}
           PACT_BROKER_FEATURES: publish_pacts_using_old_api
-
-  build-and-test-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        node-version: [16.x]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Fix node-gyp
-        run: |-
-          npm install --global node-gyp@latest
-          npm prefix -g | % {npm config set node_gyp "$_\node_modules\node-gyp\bin\node-gyp.js"}
-        shell: pwsh
-      - run: bash script/ci/build-and-test.sh
-        shell: bash
+      - run: script/ci/build-and-test.sh
+        if: runner == 'Windows'
+        # The windows build agent has trouble unpacking the tar for
+        # linux, so we only download windows binaries. This means
+        # we cannot release from Windows in CI.
+        # maybe we just need to install gunzip?
         env:
           NODE_VERSION: ${{ matrix.node-version }}
-          # The windows build agent has trouble unpacking the tar for
-          # linux, so we only download windows binaries. This means
-          # we cannot release from Windows in CI.
+          PACT_BROKER_FEATURES: publish_pacts_using_old_api
           ONLY_DOWNLOAD_PACT_FOR_WINDOWS: true
-          PACT_BROKER_FEATURES: publish_pacts_using_old_api

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,13 +8,14 @@ on:
 
 jobs:
   build-and-test-osx:
-    runs-on: [macos-latest,ubuntu-latest,windows-latest]
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash
     strategy:
       matrix:
         node-version: [16,18,20]
+        os: [macos-latest,ubuntu-latest,windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,7 @@ jobs:
       run:
         shell: bash
     strategy:
+      fail-fast: false
       matrix:
         node-version: [16,18,20]
         os: [macos-latest,ubuntu-latest,windows-latest]
@@ -38,12 +39,12 @@ jobs:
       - name: Set MSVS version
         run: npm config set msvs_version 2017
       - run: script/ci/build-and-test.sh
-        if: runner != 'Windows'
+        if: runner.os != 'Windows'
         env:
           NODE_VERSION: ${{ matrix.node-version }}
           PACT_BROKER_FEATURES: publish_pacts_using_old_api
       - run: script/ci/build-and-test.sh
-        if: runner == 'Windows'
+        if: runner.os == 'Windows'
         # The windows build agent has trouble unpacking the tar for
         # linux, so we only download windows binaries. This means
         # we cannot release from Windows in CI.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -3,6 +3,12 @@
 Do this and you should be 👌👌👌:
 
 ```
+bash script/download-libs.sh
 npm ci
 npm test
 ```
+
+
+_notes_ - As a developer you need you download the FFI libraries prior to running `npm install` / `npm ci` as the libraries will be expected to be there, and you won't have any `node_modules` installed yet.
+
+For end users, the `ffi` folder is populated, as part of the npm publishing step.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -9,6 +9,6 @@ npm test
 ```
 
 
-_notes_ - As a developer you need you download the FFI libraries prior to running `npm install` / `npm ci` as the libraries will be expected to be there, and you won't have any `node_modules` installed yet.
+_notes_ - As a developer, you need to run `bash script/download-libs.sh` to download the FFI libraries prior to running `npm install` / `npm ci` as the libraries will be expected to be there, and you won't have any `node_modules` installed yet.
 
 For end users, the `ffi` folder is populated, as part of the npm publishing step.

--- a/script/ci/build-and-test.sh
+++ b/script/ci/build-and-test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -eu
-set -eu # This needs to be here for windows bash, which doesn't read the #! line above
+set -e # This needs to be here for windows bash, which doesn't read the #! line above
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the script is running
 . "$SCRIPT_DIR"/../lib/robust-bash.sh

--- a/script/lib/download-ffi.sh
+++ b/script/lib/download-ffi.sh
@@ -17,7 +17,7 @@ if [[ $(find "${FFI_DIR}" -name "${FFI_VERSION}*") ]]; then
 fi
 
 warn "Cleaning ffi directory $FFI_DIR"
-rm -rf "${FFI_DIR:?}/*"
+rm -rf "${FFI_DIR:?}"
 mkdir -p "$FFI_DIR/osxaarch64"
 mkdir -p "$FFI_DIR/linuxaarch64"
 

--- a/test/consumer.integration.spec.ts
+++ b/test/consumer.integration.spec.ts
@@ -21,9 +21,9 @@ const { expect } = chai;
 const HOST = '127.0.0.1';
 
 const isWin = process.platform === 'win32';
-const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64'
-const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64'
-const usesOctetStream =  isLinuxArm64 || isWin || isDarwinArm64
+const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
+const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64';
+const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64;
 
 describe('FFI integration test for the HTTP Consumer API', () => {
   setLogLevel('trace');
@@ -77,8 +77,8 @@ describe('FFI integration test for the HTTP Consumer API', () => {
           baseURL: `http://${HOST}:${port}`,
           headers: {
             'content-type': usesOctetStream
-            ? 'application/octet-stream'
-            : 'application/gzip',
+              ? 'application/octet-stream'
+              : 'application/gzip',
             Accept: 'application/json',
             'x-special-header': 'header',
           },

--- a/test/consumer.integration.spec.ts
+++ b/test/consumer.integration.spec.ts
@@ -24,8 +24,9 @@ const isWin = process.platform === 'win32';
 const isLinux = process.platform === 'linux';
 const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
 const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64';
-const isCirrusCi = process.env["CIRRUS_CI"] === "true"
-const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64 || (isCirrusCi && isLinux);
+const isCirrusCi = process.env['CIRRUS_CI'] === 'true';
+const usesOctetStream =
+  isLinuxArm64 || isWin || isDarwinArm64 || (isCirrusCi && isLinux);
 
 describe('FFI integration test for the HTTP Consumer API', () => {
   setLogLevel('trace');

--- a/test/consumer.integration.spec.ts
+++ b/test/consumer.integration.spec.ts
@@ -21,6 +21,9 @@ const { expect } = chai;
 const HOST = '127.0.0.1';
 
 const isWin = process.platform === 'win32';
+const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64'
+const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64'
+const usesOctetStream =  isLinuxArm64 || isWin || isDarwinArm64
 
 describe('FFI integration test for the HTTP Consumer API', () => {
   setLogLevel('trace');
@@ -73,7 +76,9 @@ describe('FFI integration test for the HTTP Consumer API', () => {
         .request({
           baseURL: `http://${HOST}:${port}`,
           headers: {
-            'content-type': 'application/octet-stream',
+            'content-type': usesOctetStream
+            ? 'application/octet-stream'
+            : 'application/gzip',
             Accept: 'application/json',
             'x-special-header': 'header',
           },
@@ -188,7 +193,7 @@ describe('FFI integration test for the HTTP Consumer API', () => {
       interaction.withQuery('someParam', 0, 'someValue');
       interaction.withRequestBinaryBody(
         bytes,
-        isWin ? 'application/octet-stream' : 'application/gzip'
+        usesOctetStream ? 'application/octet-stream' : 'application/gzip'
       );
       interaction.withResponseBody(
         JSON.stringify({
@@ -211,7 +216,7 @@ describe('FFI integration test for the HTTP Consumer API', () => {
         .request({
           baseURL: `http://${HOST}:${port}`,
           headers: {
-            'content-type': isWin
+            'content-type': usesOctetStream
               ? 'application/octet-stream'
               : 'application/gzip',
             Accept: 'application/json',

--- a/test/consumer.integration.spec.ts
+++ b/test/consumer.integration.spec.ts
@@ -21,9 +21,11 @@ const { expect } = chai;
 const HOST = '127.0.0.1';
 
 const isWin = process.platform === 'win32';
+const isLinux = process.platform === 'linux';
 const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
 const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64';
-const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64;
+const isCirrusCi = process.env["CIRRUS_CI"] === "true"
+const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64 || (isCirrusCi && isLinux);
 
 describe('FFI integration test for the HTTP Consumer API', () => {
   setLogLevel('trace');
@@ -173,9 +175,11 @@ describe('FFI integration test for the HTTP Consumer API', () => {
 
   // See https://github.com/pact-foundation/pact-reference/issues/171 for why we have an OS switch here
   // Windows: does not have magic mime matcher, uses content-type
-  // OSX on CI: does not magic mime matcher, uses content-type
-  // OSX: has magic mime matcher, sniffs content
+  // OSX arm64: does not magic mime matcher, uses content-type
+  // OSX x86_64: has magic mime matcher, sniffs content
+  // OSX x86_64 - CI GitHub Actions: has magic mime matcher, sniffs content
   // Linux: has magic mime matcher, sniffs content
+  // Linux - CI Cirrus: does not have magic mime matcher, uses content-type
   describe('with binary data', () => {
     beforeEach(() => {
       pact = makeConsumerPact(

--- a/test/message.integration.spec.ts
+++ b/test/message.integration.spec.ts
@@ -14,8 +14,9 @@ chai.use(chaiAsPromised);
 const { expect } = chai;
 
 const isWin = process.platform === 'win32';
-const isOSX = process.platform === 'darwin';
-const isCI = process.env['CI'] === 'true';
+const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64'
+const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64'
+const usesOctetStream =  isLinuxArm64 || isWin || isDarwinArm64
 
 const getFeature = async (address: string, protoFile: string) => {
   const def = await load(protoFile);
@@ -100,7 +101,7 @@ describe('FFI integration test for the Message Consumer API', () => {
         message.givenWithParam('some state 2', 'state2 key', 'state2 val');
         message.withBinaryContents(
           bytes,
-          isWin || (isOSX && isCI)
+          usesOctetStream
             ? 'application/octet-stream'
             : 'application/gzip'
         );

--- a/test/message.integration.spec.ts
+++ b/test/message.integration.spec.ts
@@ -14,9 +14,11 @@ chai.use(chaiAsPromised);
 const { expect } = chai;
 
 const isWin = process.platform === 'win32';
+const isLinux = process.platform === 'linux';
 const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
 const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64';
-const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64;
+const isCirrusCi = process.env["CIRRUS_CI"] === "true"
+const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64 || (isCirrusCi && isLinux);
 
 const getFeature = async (address: string, protoFile: string) => {
   const def = await load(protoFile);

--- a/test/message.integration.spec.ts
+++ b/test/message.integration.spec.ts
@@ -17,8 +17,9 @@ const isWin = process.platform === 'win32';
 const isLinux = process.platform === 'linux';
 const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
 const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64';
-const isCirrusCi = process.env["CIRRUS_CI"] === "true"
-const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64 || (isCirrusCi && isLinux);
+const isCirrusCi = process.env['CIRRUS_CI'] === 'true';
+const usesOctetStream =
+  isLinuxArm64 || isWin || isDarwinArm64 || (isCirrusCi && isLinux);
 
 const getFeature = async (address: string, protoFile: string) => {
   const def = await load(protoFile);

--- a/test/message.integration.spec.ts
+++ b/test/message.integration.spec.ts
@@ -14,9 +14,9 @@ chai.use(chaiAsPromised);
 const { expect } = chai;
 
 const isWin = process.platform === 'win32';
-const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64'
-const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64'
-const usesOctetStream =  isLinuxArm64 || isWin || isDarwinArm64
+const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
+const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64';
+const usesOctetStream = isLinuxArm64 || isWin || isDarwinArm64;
 
 const getFeature = async (address: string, protoFile: string) => {
   const def = await load(protoFile);
@@ -101,9 +101,7 @@ describe('FFI integration test for the Message Consumer API', () => {
         message.givenWithParam('some state 2', 'state2 key', 'state2 val');
         message.withBinaryContents(
           bytes,
-          usesOctetStream
-            ? 'application/octet-stream'
-            : 'application/gzip'
+          usesOctetStream ? 'application/octet-stream' : 'application/gzip'
         );
         message.withMetadata('meta-key', 'meta-val');
 


### PR DESCRIPTION
- Consolidates CI test task to use single format for all three OS's
- Updates CI test task to use latest action tags (v3 checkout, v3 node)
- Remove steps no longer needed (updating node-gyp)
- Ensure FFI folder is deleted when running `download-libs.sh` otherwise it asks the user to confirm everytime. 🤯 
- Add a developer note to download the libs, before running `npm ci` when running locally
- Add macOS arm64/m1 runner test via Cirrus-CI
  - Requires rosetta due to using v1.x of pact-ruby-standalone
- Add amd64/x86_64 linux test via Cirrus-CI in preparation for ARM64 linux testing in further PR to be raised
- Test ARM64 Linux, fails as expected as per issue #416

## Smells

Cross CI provider and cross arch has shown a few inconsistencies in content-type matching, which is clearly demonstrable here. Haven't thought of a solution just yet, but this at least highlights and allows us to test more combinations than before

```
const isWin = process.platform === 'win32';
const isLinux = process.platform === 'linux';
const isDarwinArm64 = process.platform === 'darwin' && process.arch === 'arm64';
const isLinuxArm64 = process.platform === 'linux' && process.arch === 'arm64';
const isCirrusCi = process.env['CIRRUS_CI'] === 'true';
const usesOctetStream =
  isLinuxArm64 || isWin || isDarwinArm64 || (isCirrusCi && isLinux);
```
 
 
  See https://github.com/pact-foundation/pact-reference/issues/171 for why we have an OS switch here
  
  ### Previous state
  

>   Windows: does not have magic mime matcher, uses content-type
>   OSX on CI: does not magic mime matcher, uses content-type
>   OSX: has magic mime matcher, sniffs content
>   Linux: has magic mime matcher, sniffs content

 
 ### Current state
  

>   Windows: does not have magic mime matcher, uses content-type
>   OSX arm64: does not magic mime matcher, uses content-type
>   OSX x86_64: has magic mime matcher, sniffs content
>   OSX x86_64 - CI GitHub Actions: has magic mime matcher, sniffs content
>   Linux - CI Cirrus: does not have magic mime matcher, uses content-type
  