### PR TITLE
Fix/improve native logging lookup

### DIFF
--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -60,7 +60,7 @@ const bindingPaths = [
 let ffiLib: Ffi;
 
 const renderBinaryErrorMessage = (error: unknown) => {
-  logger.debug(`${supportedPlatformsMessage}`);
+  logger.debug(supportedPlatformsMessage);
   logger.error(`Failed to find native module for ${platform}: ${error}`);
   bindingPaths.forEach((bindingPath) => {
     logger.debug(

--- a/src/verifier/nativeVerifier.ts
+++ b/src/verifier/nativeVerifier.ts
@@ -11,10 +11,10 @@ import { setupVerification } from './argumentMapper';
 const pkg = require('../../package.json');
 
 export const verify = (opts: VerifierOptions): Promise<string> => {
-  const ffi = getFfiLib(opts.logLevel);
   if (opts.logLevel) {
     setLogLevel(opts.logLevel);
   }
+  const ffi = getFfiLib(opts.logLevel);
 
   const handle = ffi.pactffiVerifierNewForApplication(
     pkg.name.split('/')[1],

--- a/test/verifier.integration.spec.ts
+++ b/test/verifier.integration.spec.ts
@@ -15,7 +15,7 @@ describe('Verifier Integration Spec', () => {
   const PORT = 9123;
   const providerBaseUrl = `http://localhost:${PORT}`;
   const providerStatesSetupUrl = `${providerBaseUrl}/provider-state`;
-  // const pactBrokerBaseUrl = `http://localhost:${PORT}`;
+  const pactBrokerBaseUrl = `http://localhost:${PORT}`;
   const monkeypatchFile: string = path.resolve(__dirname, 'monkeypatch.rb');
   const DEFAULT_ARGS = {
     logLevel: 'debug' as LogLevel,
@@ -32,8 +32,8 @@ describe('Verifier Integration Spec', () => {
   after(() => server.close());
 
   context('when given a successful contract', () => {
-    context.only('with spaces in the file path', () => {
-      it.only('should return a successful promise', () =>
+    context('with spaces in the file path', () => {
+      it('should return a successful promise', () =>
         expect(
           verifierFactory({
             ...DEFAULT_ARGS,
@@ -134,165 +134,165 @@ describe('Verifier Integration Spec', () => {
     });
   });
 
-  // context('when given a failing contract', () => {
-  //   it('should return a rejected promise', () =>
-  //     expect(
-  //       verifierFactory({
-  //         providerBaseUrl,
-  //         pactUrls: [path.resolve(__dirname, 'integration/me-they-fail.json')],
-  //       }).verify()
-  //     ).to.eventually.be.rejected);
-  // });
+  context('when given a failing contract', () => {
+    it('should return a rejected promise', () =>
+      expect(
+        verifierFactory({
+          providerBaseUrl,
+          pactUrls: [path.resolve(__dirname, 'integration/me-they-fail.json')],
+        }).verify()
+      ).to.eventually.be.rejected);
+  });
 
-  // context('when given multiple successful API calls in a contract', () => {
-  //   it('should return a successful promise', () =>
-  //     expect(
-  //       verifierFactory({
-  //         providerBaseUrl,
-  //         pactUrls: [path.resolve(__dirname, 'integration/me-they-multi.json')],
-  //         providerStatesSetupUrl,
-  //       }).verify()
-  //     ).to.eventually.be.fulfilled);
-  // });
+  context('when given multiple successful API calls in a contract', () => {
+    it('should return a successful promise', () =>
+      expect(
+        verifierFactory({
+          providerBaseUrl,
+          pactUrls: [path.resolve(__dirname, 'integration/me-they-multi.json')],
+          providerStatesSetupUrl,
+        }).verify()
+      ).to.eventually.be.fulfilled);
+  });
 
-  // context('when given multiple contracts', () => {
-  //   context('from a local file', () => {
-  //     it('should return a successful promise', () =>
-  //       expect(
-  //         verifierFactory({
-  //           providerBaseUrl,
-  //           pactUrls: [
-  //             path.resolve(__dirname, 'integration/me-they-success.json'),
-  //             path.resolve(__dirname, 'integration/me-they-multi.json'),
-  //           ],
-  //           providerStatesSetupUrl,
-  //         }).verify()
-  //       ).to.eventually.be.fulfilled);
-  //   });
+  context('when given multiple contracts', () => {
+    context('from a local file', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl,
+            pactUrls: [
+              path.resolve(__dirname, 'integration/me-they-success.json'),
+              path.resolve(__dirname, 'integration/me-they-multi.json'),
+            ],
+            providerStatesSetupUrl,
+          }).verify()
+        ).to.eventually.be.fulfilled);
+    });
 
-  //   // Tests failing due to rust panic:
-  //   //
-  //   // thread '<unnamed>' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context
-  //   // with RUST_BACKTRACE=1 it seems that it relates to fetching from the broker, and something bad
-  //   // is happening in reqwest
-  //   context.skip('from a Pact Broker', () => {
-  //     context('without authentication', () => {
-  //       it('should return a successful promise', () =>
-  //         expect(
-  //           verifierFactory({
-  //             providerBaseUrl,
-  //             pactUrls: [
-  //               `${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/me/latest`,
-  //               `${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/anotherclient/latest`,
-  //             ],
-  //             providerStatesSetupUrl,
-  //           }).verify()
-  //         ).to.eventually.be.fulfilled);
-  //     });
+    // Tests failing due to rust panic:
+    //
+    // thread '<unnamed>' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context
+    // with RUST_BACKTRACE=1 it seems that it relates to fetching from the broker, and something bad
+    // is happening in reqwest
+    context.skip('from a Pact Broker', () => {
+      context('without authentication', () => {
+        it('should return a successful promise', () =>
+          expect(
+            verifierFactory({
+              providerBaseUrl,
+              pactUrls: [
+                `${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/me/latest`,
+                `${pactBrokerBaseUrl}/noauth/pacts/provider/they/consumer/anotherclient/latest`,
+              ],
+              providerStatesSetupUrl,
+            }).verify()
+          ).to.eventually.be.fulfilled);
+      });
 
-  //     context('with authentication', () => {
-  //       context('and a valid user/password', () => {
-  //         it('should return a successful promise', () =>
-  //           expect(
-  //             verifierFactory({
-  //               providerBaseUrl,
-  //               pactUrls: [
-  //                 `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
-  //                 `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
-  //               ],
-  //               providerStatesSetupUrl,
-  //               pactBrokerUsername: 'foo',
-  //               pactBrokerPassword: 'bar',
-  //             }).verify()
-  //           ).to.eventually.be.fulfilled);
-  //       });
+      context('with authentication', () => {
+        context('and a valid user/password', () => {
+          it('should return a successful promise', () =>
+            expect(
+              verifierFactory({
+                providerBaseUrl,
+                pactUrls: [
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
+                ],
+                providerStatesSetupUrl,
+                pactBrokerUsername: 'foo',
+                pactBrokerPassword: 'bar',
+              }).verify()
+            ).to.eventually.be.fulfilled);
+        });
 
-  //       context('and an invalid user/password', () => {
-  //         it('should return a rejected promise', () =>
-  //           expect(
-  //             verifierFactory({
-  //               providerBaseUrl,
-  //               pactUrls: [
-  //                 `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
-  //                 `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
-  //               ],
-  //               providerStatesSetupUrl,
-  //               pactBrokerUsername: 'foo',
-  //               pactBrokerPassword: 'baaoeur',
-  //             }).verify()
-  //           ).to.eventually.be.rejected);
+        context('and an invalid user/password', () => {
+          it('should return a rejected promise', () =>
+            expect(
+              verifierFactory({
+                providerBaseUrl,
+                pactUrls: [
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
+                ],
+                providerStatesSetupUrl,
+                pactBrokerUsername: 'foo',
+                pactBrokerPassword: 'baaoeur',
+              }).verify()
+            ).to.eventually.be.rejected);
 
-  //         it('should return the verifier error output in the returned promise', () =>
-  //           expect(
-  //             verifierFactory({
-  //               providerBaseUrl,
-  //               pactUrls: [
-  //                 `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
-  //                 `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
-  //               ],
-  //               providerStatesSetupUrl,
-  //               pactBrokerUsername: 'foo',
-  //               pactBrokerPassword: 'baaoeur',
-  //             }).verify()
-  //           ).to.eventually.be.rejected);
-  //       });
-  //     });
-  //   });
-  // });
+          it('should return the verifier error output in the returned promise', () =>
+            expect(
+              verifierFactory({
+                providerBaseUrl,
+                pactUrls: [
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/me/latest`,
+                  `${pactBrokerBaseUrl}/pacts/provider/they/consumer/anotherclient/latest`,
+                ],
+                providerStatesSetupUrl,
+                pactBrokerUsername: 'foo',
+                pactBrokerPassword: 'baaoeur',
+              }).verify()
+            ).to.eventually.be.rejected);
+        });
+      });
+    });
+  });
 
-  // context('when publishing verification results to a Pact Broker', () => {
-  //   context('and there is a valid Pact file with spaces in the path', () => {
-  //     it('should return a successful promise', () =>
-  //       expect(
-  //         verifierFactory({
-  //           providerBaseUrl,
-  //           pactUrls: [
-  //             path.resolve(
-  //               __dirname,
-  //               'integration/publish-verification-example weird path-success.json'
-  //             ),
-  //           ],
-  //           providerStatesSetupUrl,
-  //         }).verify()
-  //       ).to.eventually.be.fulfilled);
-  //   });
+  context('when publishing verification results to a Pact Broker', () => {
+    context('and there is a valid Pact file with spaces in the path', () => {
+      it('should return a successful promise', () =>
+        expect(
+          verifierFactory({
+            providerBaseUrl,
+            pactUrls: [
+              path.resolve(
+                __dirname,
+                'integration/publish-verification-example weird path-success.json'
+              ),
+            ],
+            providerStatesSetupUrl,
+          }).verify()
+        ).to.eventually.be.fulfilled);
+    });
 
-  //   context(
-  //     'and there is a valid verification HAL link in the Pact file',
-  //     () => {
-  //       it('should return a successful promise', () =>
-  //         expect(
-  //           verifierFactory({
-  //             providerBaseUrl,
-  //             pactUrls: [
-  //               path.resolve(
-  //                 __dirname,
-  //                 'integration/publish-verification-example-success.json'
-  //               ),
-  //             ],
-  //             providerStatesSetupUrl,
-  //           }).verify()
-  //         ).to.eventually.be.fulfilled);
-  //     }
-  //   );
+    context(
+      'and there is a valid verification HAL link in the Pact file',
+      () => {
+        it('should return a successful promise', () =>
+          expect(
+            verifierFactory({
+              providerBaseUrl,
+              pactUrls: [
+                path.resolve(
+                  __dirname,
+                  'integration/publish-verification-example-success.json'
+                ),
+              ],
+              providerStatesSetupUrl,
+            }).verify()
+          ).to.eventually.be.fulfilled);
+      }
+    );
 
-  //   context(
-  //     'and there is an invalid verification HAL link in the Pact file',
-  //     () => {
-  //       it('should fail with an error', () =>
-  //         expect(
-  //           verifierFactory({
-  //             providerBaseUrl,
-  //             pactUrls: [
-  //               path.resolve(
-  //                 __dirname,
-  //                 'integration/publish-verification-example-fail.json'
-  //               ),
-  //             ],
-  //             providerStatesSetupUrl,
-  //           }).verify()
-  //         ).to.eventually.be.fulfilled);
-  //     }
-  //   );
-  // });
+    context(
+      'and there is an invalid verification HAL link in the Pact file',
+      () => {
+        it('should fail with an error', () =>
+          expect(
+            verifierFactory({
+              providerBaseUrl,
+              pactUrls: [
+                path.resolve(
+                  __dirname,
+                  'integration/publish-verification-example-fail.json'
+                ),
+              ],
+              providerStatesSetupUrl,
+            }).verify()
+          ).to.eventually.be.fulfilled);
+      }
+    );
+  });
 });


### PR DESCRIPTION
this avoids the user having an error for the path lookups, when traversing each of the available binding paths, unless all paths are exhausted.

this way, if the library is available and working fine, users don't see an error in the logs.

if for whatever reason the library isn't loaded, an error message in displayed with some useful tips