### PR TITLE
fix: set engines in package.json not engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ia32",
     "arm64"
   ],
-  "engine": {
+  "engines": {
     "node": ">=16"
   },
   "repository": {


### PR DESCRIPTION
as per https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines the current config uses an incorrect key, so isn't picked up by tools like badgen and I assume others https://badgen.net/#npm/node/@pact-foundation/pact-core