### PR TITLE
chore(ci): fix release snags #456

### DIFF
--- a/script/ci/release.sh
+++ b/script/ci/release.sh
@@ -92,16 +92,7 @@ else
     echo "*** STOPPING RELEASE PROCESS ***"
     exit 1
   fi
-  # This is github actions' method for emitting multi-line values
-  RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
-  RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-  RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-  echo "notes=$RELEASE_NOTES" >> $GITHUB_OUTPUT
   npm run release
-  # Emit version to next step
-  VERSION="$("$SCRIPT_DIR/lib/get-version.sh")"
-  TAG="v${VERSION}"
-  echo "version=$VERSION" >> $GITHUB_OUTPUT
 fi
 
 "$SCRIPT_DIR"/lib/publish.sh
@@ -112,5 +103,5 @@ if [[ ${DRY_RUN:-} == 'true' ]]; then
   echo "not pushing tags as in dry run mode"
 else
   git push --follow-tags
-  gh release edit ${TAG} --title "Release ${TAG}" --repo ${REPO} --notes "${RELEASE_NOTES}" --draft=false --prerelease=false --target ${GIT_SHA}
+  gh release edit ${TAG} --title "Release ${TAG}" --repo ${REPO} --notes "${RELEASE_NOTES}" --draft=false --prerelease=false --target ${GIT_SHA} --latest
 fi


### PR DESCRIPTION
- Release note formatting was incorrect, when converting from draft (pre-release) to release.
  - This was due to a formatting step of the RELEASE_NOTES env var, for emitting in a further step for a GitHub actions publish step, this is now removed and replaced with the GitHub CLI, so isn't neccessary.
  - The VERSION/TAG equally is now no longer used for emitting in a later step.
- Now when converting to a release, it will mark as `latest`
  - docs https://cli.github.com/manual/gh_release_edit
