### PR TITLE
feat: support status code matcher via pactffi_response_status_v2

### DIFF
--- a/src/consumer/index.ts
+++ b/src/consumer/index.ts
@@ -321,8 +321,8 @@ export const makeConsumerPact = (
             filename,
             mimePartName
           ) === undefined,
-        withStatus: (status: number) =>
-          ffi.pactffiResponseStatus(interactionPtr, status),
+        withStatus: (status: number | string) =>
+          ffi.pactffiResponseStatus(interactionPtr, JSON.stringify(status)),
         withPluginRequestInteractionContents: (
           contentType: string,
           contents: string

--- a/src/ffi/types.ts
+++ b/src/ffi/types.ts
@@ -206,7 +206,7 @@ export type FfiConsumerFunctions = {
     file: string,
     partName: string
   ): void;
-  pactffiResponseStatus(handle: FfiInteractionHandle, status: number): boolean;
+  pactffiResponseStatus(handle: FfiInteractionHandle, status: string): boolean;
   pactffiWritePactFile(
     handle: FfiPactHandle,
     dir: string,


### PR DESCRIPTION
Migrates from `pactffi_response_status` to `pactffi_response_status_v2` to allow status code matching. Public interface is preserved to prevent breaking changes to intermediate Pact JS versions.