### PR TITLE
fix: 🐛 avoid node-gyp rebuild install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "snyk-protect": "snyk-protect",
     "format:base": "prettier --parser typescript",
     "format:check": "npm run format:base -- --list-different \"{src,standalone,bin,test}/**/*.{ts,tsx}\"",
-    "format:fix": "npm run format:base -- --write \"{src,standalone,bin,test}/**/*.{ts,tsx}\""
+    "format:fix": "npm run format:base -- --write \"{src,standalone,bin,test}/**/*.{ts,tsx}\"",
+    "install": ""
   },
   "prettier": "@pact-foundation/pact-js-prettier-config",
   "commit-and-tag-version": {


### PR DESCRIPTION
Add an "install" script to "override" npm behavior of adding a "node-gyp rebuild" install script on the fly when publishing.