### PR TITLE
chore: fix issue with prebuildify

### DIFF
--- a/script/ci/prebuild.sh
+++ b/script/ci/prebuild.sh
@@ -29,10 +29,12 @@ node --version
 npm --version
 echo "OS: $OS"
 echo "ARCH: $ARCH"
-PREBUILDIFY_VERSION=5.0.1
+PREBUILDIFY_VERSION=6.0.1
+NODE_VERSION=$(node -p process.version)
 
 ./script/download-libs.sh
 npm ci --ignore-scripts
+export npm_config_target=${NODE_VERSION}
 npx --yes prebuildify@${PREBUILDIFY_VERSION} --napi
 ls prebuilds/**/*
 case $OS in
@@ -86,4 +88,4 @@ case $OS in
     ;;
 esac
 ls
-rm -rf ffi build 
+rm -rf ffi build


### PR DESCRIPTION
Prebuildify is for some reason looking for node 22 headers, this change:

* sets node target based on current node version
* update to prebuildify 6.0.1 to fix windows EINVAL issue

