### PR TITLE
Chore/set prebuild names

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,6 +83,7 @@ jobs:
 
     env:
       NODE_VERSION: ${{ matrix.node-version }}
+      LOG_LEVEL: debug
 
     steps:
       - uses: actions/checkout@v4

--- a/script/ci/prebuild.sh
+++ b/script/ci/prebuild.sh
@@ -35,7 +35,7 @@ NODE_VERSION=$(node -p process.version)
 ./script/download-libs.sh
 npm ci --ignore-scripts
 export npm_config_target=${NODE_VERSION}
-npx --yes prebuildify@${PREBUILDIFY_VERSION} --napi
+npx --yes prebuildify@${PREBUILDIFY_VERSION} --napi --name node.napi.node
 ls prebuilds/**/*
 case $OS in
   darwin)


### PR DESCRIPTION
The latest `prebuildify`  seems to default the name to the package name, however our scripts expect `node.napi.node`. This change uses the undocumented `--name` flag on prebuildify to set that.

<img width="348" alt="Screenshot 2024-04-23 at 9 21 36 PM" src="https://github.com/pact-foundation/pact-js-core/assets/53900/20b08ae3-cb94-4577-8870-734e91ee870f">

