### PR TITLE
fix: set process.stdout._handle.setBlocking(true) on ffi init

### DIFF
--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -88,6 +88,13 @@ let ffi: typeof ffiLib;
 let ffiLogLevel: LogLevel;
 
 const initialiseFfi = (logLevel: LogLevel): typeof ffi => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (process.stdout._handle) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    process.stdout._handle.setBlocking(true);
+  }
   logger.debug(`Initalising native core at log level '${logLevel}'`);
   ffiLogLevel = logLevel;
   try {


### PR DESCRIPTION
fixes https://github.com/pact-foundation/pact-js/issues/1216

Large number of pact verifications fail when run in parallel
