### PR TITLE
fix: shell escaping

### DIFF
--- a/bin/pact-broker.ts
+++ b/bin/pact-broker.ts
@@ -3,12 +3,14 @@
 import childProcess = require('child_process');
 import rubyStandalone from '../src/pact-standalone';
 
+const isWindows = process.platform === 'win32'
+const opts = isWindows ? { shell: true } : {}
 const { error, status } = childProcess.spawnSync(
   rubyStandalone.brokerFullPath,
   process.argv.slice(2),
   {
     stdio: 'inherit',
-    shell: true,
+    ...opts
   }
 );
 if (error) throw error;

--- a/bin/pact-broker.ts
+++ b/bin/pact-broker.ts
@@ -1,16 +1,20 @@
 #!/usr/bin/env node
 
 import childProcess = require('child_process');
-import rubyStandalone from '../src/pact-standalone';
+import {
+  standalone,
+  standaloneUseShell,
+  setStandaloneArgs,
+} from '../src/pact-standalone';
 
-const isWindows = process.platform === 'win32'
-const opts = isWindows ? { shell: true } : {}
+const args = process.argv.slice(2);
+const opts = standaloneUseShell ? { shell: true } : {};
 const { error, status } = childProcess.spawnSync(
-  rubyStandalone.brokerFullPath,
-  process.argv.slice(2),
+  standalone().brokerFullPath,
+  setStandaloneArgs(args, standaloneUseShell),
   {
     stdio: 'inherit',
-    ...opts
+    ...opts,
   }
 );
 if (error) throw error;

--- a/bin/pact-message.ts
+++ b/bin/pact-message.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 
 import childProcess = require('child_process');
-import rubyStandalone from '../src/pact-standalone';
+import {
+  standalone,
+  standaloneUseShell,
+  setStandaloneArgs,
+} from '../src/pact-standalone';
 
-const isWindows = process.platform === 'win32'
-const opts = isWindows ? { shell: true } : {}
+const args = process.argv.slice(2);
+const opts = standaloneUseShell ? { shell: true } : {};
+
 const { error, status } = childProcess.spawnSync(
-  rubyStandalone.messageFullPath,
-  process.argv.slice(2),
+  standalone().messageFullPath,
+  setStandaloneArgs(args, standaloneUseShell),
   {
     stdio: 'inherit',
-    ...opts
+    ...opts,
   }
 );
 if (error) throw error;

--- a/bin/pact-message.ts
+++ b/bin/pact-message.ts
@@ -3,12 +3,14 @@
 import childProcess = require('child_process');
 import rubyStandalone from '../src/pact-standalone';
 
+const isWindows = process.platform === 'win32'
+const opts = isWindows ? { shell: true } : {}
 const { error, status } = childProcess.spawnSync(
   rubyStandalone.messageFullPath,
   process.argv.slice(2),
   {
     stdio: 'inherit',
-    shell: true,
+    ...opts
   }
 );
 if (error) throw error;

--- a/bin/pact-mock-service.ts
+++ b/bin/pact-mock-service.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 
 import childProcess = require('child_process');
-import rubyStandalone from '../src/pact-standalone';
+import {
+  standalone,
+  standaloneUseShell,
+  setStandaloneArgs,
+} from '../src/pact-standalone';
 
-const isWindows = process.platform === 'win32'
-const opts = isWindows ? { shell: true } : {}
+const args = process.argv.slice(2);
+const opts = standaloneUseShell ? { shell: true } : {};
+
 const { error, status } = childProcess.spawnSync(
-  rubyStandalone.mockServiceFullPath,
-  process.argv.slice(2),
+  standalone().mockServiceFullPath,
+  setStandaloneArgs(args, standaloneUseShell),
   {
     stdio: 'inherit',
-    ...opts
+    ...opts,
   }
 );
 if (error) throw error;

--- a/bin/pact-mock-service.ts
+++ b/bin/pact-mock-service.ts
@@ -3,12 +3,14 @@
 import childProcess = require('child_process');
 import rubyStandalone from '../src/pact-standalone';
 
+const isWindows = process.platform === 'win32'
+const opts = isWindows ? { shell: true } : {}
 const { error, status } = childProcess.spawnSync(
   rubyStandalone.mockServiceFullPath,
   process.argv.slice(2),
   {
     stdio: 'inherit',
-    shell: true,
+    ...opts
   }
 );
 if (error) throw error;

--- a/bin/pact-provider-verifier.ts
+++ b/bin/pact-provider-verifier.ts
@@ -3,12 +3,14 @@
 import childProcess = require('child_process');
 import rubyStandalone from '../src/pact-standalone';
 
+const isWindows = process.platform === 'win32'
+const opts = isWindows ? { shell: true } : {}
 const { error, status } = childProcess.spawnSync(
   rubyStandalone.verifierFullPath,
   process.argv.slice(2),
   {
     stdio: 'inherit',
-    shell: true,
+    ...opts
   }
 );
 if (error) throw error;

--- a/bin/pact-provider-verifier.ts
+++ b/bin/pact-provider-verifier.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 
 import childProcess = require('child_process');
-import rubyStandalone from '../src/pact-standalone';
+import {
+  standalone,
+  standaloneUseShell,
+  setStandaloneArgs,
+} from '../src/pact-standalone';
 
-const isWindows = process.platform === 'win32'
-const opts = isWindows ? { shell: true } : {}
+const args = process.argv.slice(2);
+const opts = standaloneUseShell ? { shell: true } : {};
+
 const { error, status } = childProcess.spawnSync(
-  rubyStandalone.verifierFullPath,
-  process.argv.slice(2),
+  standalone().verifierFullPath,
+  setStandaloneArgs(args, standaloneUseShell),
   {
     stdio: 'inherit',
-    ...opts
+    ...opts,
   }
 );
 if (error) throw error;

--- a/bin/pact-stub-service.ts
+++ b/bin/pact-stub-service.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 
 import childProcess = require('child_process');
-import rubyStandalone from '../src/pact-standalone';
+import {
+  standalone,
+  standaloneUseShell,
+  setStandaloneArgs,
+} from '../src/pact-standalone';
 
-const isWindows = process.platform === 'win32'
-const opts = isWindows ? { shell: true } : {}
+const args = process.argv.slice(2);
+const opts = standaloneUseShell ? { shell: true } : {};
+
 const { error, status } = childProcess.spawnSync(
-  rubyStandalone.stubFullPath,
-  process.argv.slice(2),
+  standalone().stubFullPath,
+  setStandaloneArgs(args, standaloneUseShell),
   {
     stdio: 'inherit',
-    ...opts
+    ...opts,
   }
 );
 if (error) throw error;

--- a/bin/pact-stub-service.ts
+++ b/bin/pact-stub-service.ts
@@ -3,12 +3,14 @@
 import childProcess = require('child_process');
 import rubyStandalone from '../src/pact-standalone';
 
+const isWindows = process.platform === 'win32'
+const opts = isWindows ? { shell: true } : {}
 const { error, status } = childProcess.spawnSync(
   rubyStandalone.stubFullPath,
   process.argv.slice(2),
   {
     stdio: 'inherit',
-    shell: true,
+    ...opts
   }
 );
 if (error) throw error;

--- a/bin/pact.ts
+++ b/bin/pact.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 
 import childProcess = require('child_process');
-import rubyStandalone from '../src/pact-standalone';
+import {
+  standalone,
+  standaloneUseShell,
+  setStandaloneArgs,
+} from '../src/pact-standalone';
 
-const isWindows = process.platform === 'win32'
-const opts = isWindows ? { shell: true } : {}
+const args = process.argv.slice(2);
+const opts = standaloneUseShell ? { shell: true } : {};
+
 const { error, status } = childProcess.spawnSync(
-  rubyStandalone.pactFullPath,
-  process.argv.slice(2),
+  standalone().pactFullPath,
+  setStandaloneArgs(args, standaloneUseShell),
   {
     stdio: 'inherit',
-    ...opts
+    ...opts,
   }
 );
 if (error) throw error;

--- a/bin/pact.ts
+++ b/bin/pact.ts
@@ -3,12 +3,14 @@
 import childProcess = require('child_process');
 import rubyStandalone from '../src/pact-standalone';
 
+const isWindows = process.platform === 'win32'
+const opts = isWindows ? { shell: true } : {}
 const { error, status } = childProcess.spawnSync(
   rubyStandalone.pactFullPath,
   process.argv.slice(2),
   {
     stdio: 'inherit',
-    shell: true,
+    ...opts
   }
 );
 if (error) throw error;

--- a/bin/pactflow.ts
+++ b/bin/pactflow.ts
@@ -3,12 +3,14 @@
 import childProcess = require('child_process');
 import rubyStandalone from '../src/pact-standalone';
 
+const isWindows = process.platform === 'win32'
+const opts = isWindows ? { shell: true } : {}
 const { error, status } = childProcess.spawnSync(
   rubyStandalone.pactflowFullPath,
   process.argv.slice(2),
   {
     stdio: 'inherit',
-    shell: true,
+    ...opts
   }
 );
 if (error) throw error;

--- a/bin/pactflow.ts
+++ b/bin/pactflow.ts
@@ -1,16 +1,21 @@
 #!/usr/bin/env node
 
 import childProcess = require('child_process');
-import rubyStandalone from '../src/pact-standalone';
+import {
+  standalone,
+  standaloneUseShell,
+  setStandaloneArgs,
+} from '../src/pact-standalone';
 
-const isWindows = process.platform === 'win32'
-const opts = isWindows ? { shell: true } : {}
+const args = process.argv.slice(2);
+const opts = standaloneUseShell ? { shell: true } : {};
+
 const { error, status } = childProcess.spawnSync(
-  rubyStandalone.pactflowFullPath,
-  process.argv.slice(2),
+  standalone().pactflowPath,
+  setStandaloneArgs(args, standaloneUseShell),
   {
     stdio: 'inherit',
-    ...opts
+    ...opts,
   }
 );
 if (error) throw error;


### PR DESCRIPTION
- Initial issue 
  - https://github.com/pact-foundation/pact-js-core/issues/503

- Fix
  - https://github.com/pact-foundation/pact-js-core/pull/504

- Regressions
  - fixes https://github.com/pact-foundation/pact-js-core/issues/506
    - Cause(s)
      - Change not scoped for only `win32` platform (windows only)
      - use of `shell` does not behave the same with regards to escaping of provided user arguments
      
      
- Reproducers
  - [Failing CI](https://github.com/YOU54F/pact-js/actions/runs/9271916204)
  - [Passing CI](https://github.com/YOU54F/pact-js/actions/runs/9275156872)
  
## pact-core@14.3.5 
  
⛔
  
`npx --package=@pact-foundation/pact-core@14.3.5 -c 'pact-broker publish "my pact.json" --consumer-app-version 1'`


## pact-core@14.3.4

✅

`npx --package=@pact-foundation/pact-core@14.3.4 -c 'pact-broker publish "my pact.json" --consumer-app-version 1'`
 
 ## you54f/pact-core@15.0.1
 
 ✅
 
`npx --package=@you54f/pact-core@15.0.1 -c 'pact-broker publish "my pact.json" --consumer-app-version=1'`
  