### PR TITLE
fix: add deprecation warnings for pact cli tools in pact-js-core

### DIFF
--- a/bin/pact-broker.ts
+++ b/bin/pact-broker.ts
@@ -5,8 +5,10 @@ import {
   standalone,
   standaloneUseShell,
   setStandaloneArgs,
+  showStandaloneDeprecationWarning,
 } from '../src/pact-standalone';
 
+showStandaloneDeprecationWarning();
 const args = process.argv.slice(2);
 const opts = standaloneUseShell ? { shell: true } : {};
 const { error, status } = childProcess.spawnSync(

--- a/bin/pact-message.ts
+++ b/bin/pact-message.ts
@@ -5,8 +5,10 @@ import {
   standalone,
   standaloneUseShell,
   setStandaloneArgs,
+  showStandaloneDeprecationWarning,
 } from '../src/pact-standalone';
 
+showStandaloneDeprecationWarning();
 const args = process.argv.slice(2);
 const opts = standaloneUseShell ? { shell: true } : {};
 

--- a/bin/pact-mock-service.ts
+++ b/bin/pact-mock-service.ts
@@ -5,8 +5,10 @@ import {
   standalone,
   standaloneUseShell,
   setStandaloneArgs,
+  showStandaloneDeprecationWarning,
 } from '../src/pact-standalone';
 
+showStandaloneDeprecationWarning();
 const args = process.argv.slice(2);
 const opts = standaloneUseShell ? { shell: true } : {};
 

--- a/bin/pact-provider-verifier.ts
+++ b/bin/pact-provider-verifier.ts
@@ -5,8 +5,10 @@ import {
   standalone,
   standaloneUseShell,
   setStandaloneArgs,
+  showStandaloneDeprecationWarning,
 } from '../src/pact-standalone';
 
+showStandaloneDeprecationWarning();
 const args = process.argv.slice(2);
 const opts = standaloneUseShell ? { shell: true } : {};
 

--- a/bin/pact-stub-service.ts
+++ b/bin/pact-stub-service.ts
@@ -5,8 +5,10 @@ import {
   standalone,
   standaloneUseShell,
   setStandaloneArgs,
+  showStandaloneDeprecationWarning,
 } from '../src/pact-standalone';
 
+showStandaloneDeprecationWarning();
 const args = process.argv.slice(2);
 const opts = standaloneUseShell ? { shell: true } : {};
 

--- a/bin/pact.ts
+++ b/bin/pact.ts
@@ -5,8 +5,10 @@ import {
   standalone,
   standaloneUseShell,
   setStandaloneArgs,
+  showStandaloneDeprecationWarning,
 } from '../src/pact-standalone';
 
+showStandaloneDeprecationWarning();
 const args = process.argv.slice(2);
 const opts = standaloneUseShell ? { shell: true } : {};
 

--- a/bin/pactflow.ts
+++ b/bin/pactflow.ts
@@ -5,8 +5,10 @@ import {
   standalone,
   standaloneUseShell,
   setStandaloneArgs,
+  showStandaloneDeprecationWarning,
 } from '../src/pact-standalone';
 
+showStandaloneDeprecationWarning();
 const args = process.argv.slice(2);
 const opts = standaloneUseShell ? { shell: true } : {};
 

--- a/script/lib/download-file.sh
+++ b/script/lib/download-file.sh
@@ -16,7 +16,19 @@ function download_to {
   OUTPUT_FILE="$2"
   debug_log "doing curl of: '$URL', saving in $OUTPUT_FILE"
 
-  HTTP_CODE="$(curl --silent --output "$OUTPUT_FILE" --write-out "%{http_code}" --location "$URL")"
+  if [[ "$(uname -m)" == "Darwin" ]] || [[ "$(uname -m)" == "Linux" ]]; then
+    HTTP_CODE="$(curl --silent --output "$OUTPUT_FILE" --write-out "%{http_code}" --location "$URL")"
+  else
+  # temp workaround for curl 8.8.x error on windows gha runners
+  # https://github.com/curl/curl/issues/13845
+    curl --silent --output "$OUTPUT_FILE" --location "$URL"
+    if [ $? -ne 0 ]; then
+      error "Unable to download file at url ${URL}"
+      exit 1
+    else
+      HTTP_CODE=200
+    fi
+  fi
   debug_log "did curl, http code was '${HTTP_CODE}'"
   if [[ "${HTTP_CODE}" -lt 200 || "${HTTP_CODE}" -gt 299 ]] ; then
     error "Unable to download file at url ${URL}"

--- a/src/pact-standalone.ts
+++ b/src/pact-standalone.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { getBinaryEntry } from '../standalone/install';
 import pactEnvironment from './pact-environment';
+import logger from './logger';
 
 export interface PactStandalone {
   cwd: string;
@@ -108,6 +109,17 @@ export function setStandaloneArgs(
     parsedArgs = parseArgs(unparsed_args);
   }
   return parsedArgs;
+}
+
+export function showStandaloneDeprecationWarning(): void {
+  const silenceDeprecationWarnings =
+    process.env['PACT_SILENCE_DEPRECATION_WARNINGS'] === 'true';
+
+  if (!silenceDeprecationWarnings) {
+    logger.warn(
+      'DEPRECATION NOTICE: \n  pact standalone tools will be removed in pact-js-core 15.x. \n  Please update imports to @pact-foundation/pact-cli \n  https://github.com/pact-foundation/pact-js-core/issues/488'
+    );
+  }
 }
 
 export const standaloneUseShell = isWindows;

--- a/src/service.ts
+++ b/src/service.ts
@@ -12,6 +12,7 @@ import spawn, { CliVerbOptions } from './spawn';
 import { LogLevel } from './logger/types';
 import logger, { setLogLevel } from './logger';
 import { ServiceOptions } from './types';
+import { showStandaloneDeprecationWarning } from './pact-standalone';
 
 // Get a reference to the global setTimeout object in case it is mocked by a testing library later
 const { setTimeout } = global;
@@ -93,6 +94,8 @@ export abstract class AbstractService extends events.EventEmitter {
           'Like a Boss, you used a port outside of the recommended range (1024 to 49151); I too like to live dangerously.'
         );
       }
+
+      showStandaloneDeprecationWarning();
     }
 
     // ssl check


### PR DESCRIPTION
## Motivation

Inform users of upcoming breaking change in #513 

## Considerations

Users may be setup to output in json format. This warning will appear conditionally I believe, so may mess up workflows if one if using the json output from stdout and now has a warning in it.

An option to silence the warnings is provided if `PACT_SILENCE_DEPRECATION_WARNINGS` is set to `true`

## Breaking change detail

All CLI/API functionality provided by the Pact CLI tools (ruby based) will be moved in pact-js-core 15.x to pact-js-cli.

* Repo

    * https://github.com/pact-foundation/pact-js-cli/

* NPM Package

    * https://www.npmjs.com/package/@pact-foundation/pact-cli

* imports

    * `@pact-foundation/pact-core` imports will now become `@pact-foundation/pact-cli` for programatic usage of the CLI tools

* npx usage

    * `npx --package=@pact-foundation/pact-cli@15.0.1 -c pact-broker`
