### PR TITLE
Chore/upgrade to pact ffi 0.4.22

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20, 22]
+        node-version: [16, 18, 20, 22.4.1]
         os: [macos-14, macos-12, ubuntu-latest, windows-latest]
         docker: [false]
         include:
@@ -116,17 +116,17 @@ jobs:
             docker: true
             alpine: false
             arch: arm64
-            node-version: 22
+            node-version: 22.4.1
           - os: ubuntu-latest
             docker: true
             alpine: true
             arch: arm64
-            node-version: 22
+            node-version: 22.4.1
           - os: ubuntu-latest
             docker: true
             alpine: true
             arch: amd64
-            node-version: 22
+            node-version: 22.4.1
           - os: ubuntu-latest
             docker: true
             alpine: false

--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -4,7 +4,7 @@ import logger, { DEFAULT_LOG_LEVEL } from '../logger';
 import { LogLevel } from '../logger/types';
 import { Ffi } from './types';
 
-export const PACT_FFI_VERSION = '0.4.21';
+export const PACT_FFI_VERSION = '0.4.22';
 
 // supported prebuilds
 // darwin-arm64

--- a/test/matt.consumer.integration.spec.ts
+++ b/test/matt.consumer.integration.spec.ts
@@ -38,6 +38,7 @@ const sendMattMessageTCP = (
   return new Promise((resolve) => {
     socket.on('data', (data) => {
       resolve(parseMattMessage(data.toString()));
+      socket.destroy();
     });
   });
 };

--- a/test/matt.provider.integration.spec.ts
+++ b/test/matt.provider.integration.spec.ts
@@ -40,6 +40,7 @@ const startTCPServer = (host: string, port: number) => {
         sock.write(generateMattMessage('message not understood'));
       }
       sock.write('\n');
+      sock.destroy();
     });
   });
 


### PR DESCRIPTION
Update to [libpact_ffi 0.4.22](https://github.com/pact-foundation/pact-reference/releases/tag/libpact_ffi-v0.4.22)

Includes [windows plugin shutdown fix](https://github.com/pact-foundation/pact-plugins/pull/67)

Introduces failures in windows matt plugin tests with tcp connections (solved by calling socket.end/destroy)