### PR TITLE
fix: logFile default to info if undefined, warn if error setting

### DIFF
--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -132,11 +132,14 @@ export const getFfiLib = (
       logFile
     );
     if (logFile) {
-      logger.debug(
-        `writing log file at level ${FfiLogLevelFilter[logLevel]} to ${logFile}`
+      logger.debug(`writing log file at level ${logLevel} to ${logFile}`);
+      const res = ffiLib.pactffiLogToFile(
+        logFile,
+        FfiLogLevelFilter[logLevel] ?? 3
       );
-      const res = ffiLib.pactffiLogToFile(logFile, FfiLogLevelFilter[logLevel]);
-      logger.debug(`result of writing to file '${res}'`);
+      if (res !== 0) {
+        logger.warn(`Failed to write log file to ${logFile}, reason: ${res}`);
+      }
     } else {
       ffiLib.pactffiInitWithLogLevel(logLevel);
     }

--- a/src/ffi/types.ts
+++ b/src/ffi/types.ts
@@ -110,12 +110,11 @@ export enum FfiFunctionResult {
 }
 
 export enum FfiLogLevelFilter {
-  LOG_LEVEL_OFF = 0,
-  LOG_LEVEL_ERROR,
-  LOG_LEVEL_WARN,
-  LOG_LEVEL_INFO,
-  LOG_LEVEL_DEBUG,
-  LOG_LEVEL_TRACE,
+  'error' = 1,
+  'warn' = 2,
+  'info' = 3,
+  'debug' = 4,
+  'trace' = 5,
 }
 
 export type Ffi = {


### PR DESCRIPTION
the existing enum FfiLogLevelFilter was not used, and its values

 LOG_LEVEL_* as not the same as LogLevel types

LogLevel = debug | error | info | trace | warn;

This fixes it for the verifier exposed in pact-js, automatically consuming this fix release.

pact-js consumer interfaces, still require updating to pass in the logFile argument.
