### PR TITLE
chore(ci): deduplicate CI runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,8 +2,11 @@ name: Build and test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
-    branches: [master]
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We don't need to run CI on every push to any branch _and_ PRs targetting master. This change ensures that the following are targetted:

- New commits to `master`
- PRs targetting `master`

Specifically, commits to new branches are _not_ tested unless they are part of a PR.