### PR TITLE
Feat/optional arch specific binaries

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -64,33 +64,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        if: github.ref == 'refs/heads/master'
         with:
           fetch-depth: 0
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        if: github.ref == 'refs/heads/master'
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      - if: runner.os == 'Windows'
+      - if: ${{ runner.os == 'Windows' && github.ref == 'refs/heads/master'}}
         run: echo "ONLY_DOWNLOAD_PACT_FOR_WINDOWS=true" >> $GITHUB_ENV
 
-      - if: ${{ matrix.docker == true && matrix.alpine == true }}
+      - if: ${{ matrix.docker == true && matrix.alpine == true && github.ref == 'refs/heads/master'}}
         name: prebuild linux ${{ matrix.arch }} musl
         run: docker run -v $PWD:/home --platform linux/${{ matrix.arch }} --rm node:20-alpine bin/sh -c 'apk add bash && cd /home && bash -c "/home/script/ci/prebuild-alpine.sh" && rm -rf ffi node_modules'
 
-      - if: ${{ matrix.docker == true && matrix.alpine != true }}
+      - if: ${{ matrix.docker == true && matrix.alpine != true && github.ref == 'refs/heads/master' }}
         name: prebuild linux ${{ matrix.arch }}
         run: docker run -v $PWD:/home --platform linux/${{ matrix.arch }} --rm node:20 bin/bash -c 'cd /home && /home/script/ci/prebuild.sh && rm -rf ffi node_modules'
 
       - run: sudo chown -R $(id -u):$(id -g) prebuilds
-        if: ${{ matrix.docker == true }}
+        if: ${{ matrix.docker == true && github.ref == 'refs/heads/master' }}
 
       - run: ./script/ci/prebuild.sh
-        if: ${{ matrix.docker != true }}
+        if: ${{ matrix.docker != true && github.ref == 'refs/heads/master'}}
 
       - name: Upload prebuild for ${{ runner.os }}-${{ runner.arch }}
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        if: github.ref == 'refs/heads/master'
         with:
           path: prebuilds/*.tar.gz
           name: artifact-${{ matrix.docker == true && matrix.alpine == true && 'linux-musl' || matrix.docker == true && matrix.alpine == false && 'linux' || matrix.os }}-${{ matrix.arch }}
@@ -156,7 +159,12 @@ jobs:
           fetch-depth: 0
 
       - name: Download prebuilds
+        if: github.ref == 'refs/heads/master'
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      - run: FETCH_ASSETS=true REPO=pact-foundation/pact-js-core ./script/ci/check-release-libs.sh --fetch-assets
+        if: github.ref != 'refs/heads/master'
+        env:
+            GITHUB_TOKEN: ${{ github.token }}
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
@@ -173,11 +181,11 @@ jobs:
 
       - if: ${{ matrix.docker == true && matrix.alpine == true && matrix.arch == 'amd64' && matrix.os == 'ubuntu-latest' }}
         name: test linux amd64 musl
-        run: docker run -v $PWD:/home --platform linux/${{ matrix.arch }} --rm node:${{ matrix.node-version }}-alpine bin/sh -c 'apk add bash curl gcompat file && cd /home && /home/script/ci/unpack-and-test.sh'
+        run: docker run -v $PWD:/home --platform linux/${{ matrix.arch }} --rm node:${{ matrix.node-version }}-alpine bin/sh -c 'apk add jq gettext-envsubst bash curl gcompat file && cd /home && /home/script/ci/unpack-and-test.sh'
 
       - if: ${{ matrix.docker == true && matrix.alpine == true && matrix.arch == 'arm64' && matrix.os == 'ubuntu-24.04-arm' }}
         name: test linux arm64 musl
-        run: docker run -v $PWD:/home --platform linux/${{ matrix.arch }} --rm node:${{ matrix.node-version }}-alpine bin/sh -c 'apk add bash curl file protoc protobuf-dev && cd /home && /home/script/ci/unpack-and-test.sh'
+        run: docker run -v $PWD:/home --platform linux/${{ matrix.arch }} --rm node:${{ matrix.node-version }}-alpine bin/sh -c 'apk add jq gettext-envsubst bash curl file protoc protobuf-dev && cd /home && /home/script/ci/unpack-and-test.sh'
 
   release_dry_run:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ reports
 tmp
 .tmp
 test/__testoutput__
+
+# platform-arch specific packages
+@pact-foundation/*

--- a/.npmignore
+++ b/.npmignore
@@ -84,10 +84,17 @@ script
 binding.gyp
 native
 
-.cirrus
 .gitattributes
 DEVELOPER.md
 RELEASING.md
 test.js
 tsconfig.build.json
 tsconfig.json
+
+# Standalone Binaries - Published as seperate packages
+@pact-foundation/
+
+# Cross packaging files
+Makefile
+package.json.tmpl
+prebuilds

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -4,12 +4,24 @@ Pact-Js-Core uses FFI bindings from the pact-reference project, which are prebui
 
 Do this and you should be 👌👌👌:
 
-```
+```sh
 bash script/ci/prebuild.sh
-npm ci --ignore-scripts
+supported_platforms=$(./script/ci/build-opt-dependencies.sh determine_platform) 
+./script/ci/build-opt-dependencies.sh build
+./script/ci/build-opt-dependencies.sh link
 npm run build
-npm test
+npm run test
 ```
+
+set supported platform to one of these values
+
+- `linux-x64-glibc`
+- `linux-arm64-glibc`
+- `linux-x64-musl`
+- `linux-arm64-musl`
+- `darwin-x64`
+- `darwin-arm64`
+- `windows-x64`
 
 _notes_ - 
 
@@ -32,7 +44,89 @@ Alternatively you can run the following, which will not create a prebuild, but i
 bash script/download-libs.sh
 npm ci
 npm run build
-npm test
+npm run test
+```
+
+## Creating Platform specific packages
+
+We create cross-platform and architecture binaries which are published individually to NPM, and consumed in this project.
+
+### Download prebuilt binaries for all platforms
+
+```sh
+./script/ci/build_opt_dependencies.sh libs v15.2.1
+```
+
+Tag is optional and defaults to latest
+
+This will run the following script, which will grab the latest prebuilt binaries from GitHub.
+
+```sh
+FETCH_ASSETS=true ./script/ci/check-release-libs.sh --fetch-assets -t v15.2.1
+```
+
+### Building all platform specific npm packages
+
+```sh
+./script/ci/build_opt_dependencies.sh build
+```
+
+### Building individual platform specific npm package
+
+Supported platforms are
+
+- linux-x64-glibc
+- linux-arm64-glibc
+- linux-x64-musl
+- linux-arm64-musl
+- darwin-x64
+- darwin-arm64
+- windows-x64
+
+You can detect your platform with
+
+```sh
+./script/ci/build-opt-dependencies.sh determine_platform
+```
+
+You can build with one
+
+```sh
+supported_platforms=$(./script/ci/build-opt-dependencies.sh determine_platform) ./script/ci/build-opt-dependencies.sh build
+```
+
+or all
+
+```sh
+./script/ci/build-opt-dependencies.sh build
+```
+
+### Linking arch specific package, for your local build
+
+Make link will try to link all available packages, for all available platforms, and will link any that apply
+
+```sh
+./script/ci/build-opt-dependencies.sh
+```
+
+You can scope it with `supported_platforms`
+
+```sh
+supported_platforms=$(./script/ci/build-opt-dependencies.sh determine_platform) ./script/ci/build-opt-dependencies.sh link
+```
+
+### Publishing packages
+
+Dry run publishing optional packages, (default)
+
+```sh
+./script/ci/build-opt-dependencies.sh publish
+```
+
+Publishing packages with `--dry-run` option removed.
+
+```sh
+PUBLISH=true ./script/ci/build-opt-dependencies.sh publish
 ```
 
 ### Linux x86_64 Task
@@ -50,43 +144,3 @@ npm test
 ```sh
 act --container-architecture linux/amd64 -W .github/workflows/build-and-test.yml --artifact-server-path tmp
 ```
-
-### MacOS ARM64 Task
-
-#### Pre Reqs
-
-1. Arm64 Mac
-2. Cirrus-Cli
-3. Tart.run
-
-
-```sh
-cirrus run --output github-actions macos_arm --artifacts-dir tmp
-```
-
-### Linux ARM64 Task
-
-#### Pre Reqs
-
-1. Arm64 Machine
-
-### CI Locally
-
-1. Arm64 Machine
-2. Docker / Podman
-3. Cirrus-Cli
-
-
-```sh
-cirrus run --output github-actions linux_arm --artifacts-dir tmp
-```
-
-#### Publishing Assets
-
-MacOS ARM64
-
-`cirrus run --output github-actions macos_arm --artifacts-dir tmp --environment GITHUB_TOKEN=$GITHUB_TOKEN --environment CIRRUS_RELEASE=test --environment CIRRUS_REPO_FULL_NAME=pact-foundation/pact-js-core;`
-
-Linux ARM64
-
-`cirrus run --output github-actions linux_arm --artifacts-dir tmp --environment GITHUB_TOKEN=$GITHUB_TOKEN --environment CIRRUS_RELEASE=test --environment CIRRUS_REPO_FULL_NAME=pact-foundation/pact-js-core;`

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       ],
       "dependencies": {
         "check-types": "7.4.0",
+        "detect-libc": "^2.0.3",
         "node-gyp-build": "^4.6.0",
         "pino": "^8.7.0",
         "pino-pretty": "^9.1.1",
@@ -81,6 +82,15 @@
       },
       "engines": {
         "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@pact-foundation/pact-core-darwin-arm64": "15.2.1",
+        "@pact-foundation/pact-core-darwin-x64": "15.2.1",
+        "@pact-foundation/pact-core-linux-arm64-glibc": "15.2.1",
+        "@pact-foundation/pact-core-linux-arm64-musl": "15.2.1",
+        "@pact-foundation/pact-core-linux-x64-glibc": "15.2.1",
+        "@pact-foundation/pact-core-linux-x64-musl": "15.2.1",
+        "@pact-foundation/pact-core-windows-x64": "15.2.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2601,6 +2611,15 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -9861,6 +9880,11 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
+    },
+    "detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
     },
     "detect-newline": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "check-types": "7.4.0",
+    "detect-libc": "^2.0.3",
     "node-gyp-build": "^4.6.0",
     "pino": "^8.7.0",
     "pino-pretty": "^9.1.1",
@@ -160,5 +161,14 @@
       }
     ]
   },
-  "snyk": true
+  "snyk": true,
+  "optionalDependencies": {
+    "@pact-foundation/pact-core-darwin-arm64": "15.2.1",
+    "@pact-foundation/pact-core-darwin-x64": "15.2.1",
+    "@pact-foundation/pact-core-linux-arm64-glibc": "15.2.1",
+    "@pact-foundation/pact-core-linux-arm64-musl": "15.2.1",
+    "@pact-foundation/pact-core-linux-x64-glibc": "15.2.1",
+    "@pact-foundation/pact-core-linux-x64-musl": "15.2.1",
+    "@pact-foundation/pact-core-windows-x64": "15.2.1"
+  }
 }

--- a/package.json.tmpl
+++ b/package.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "name": "${node_pkg}",
+  "version": "${pkg_version}",
+  "description": "Platform/arch specific libpact_ffi binaries for @pact-foundation/pact-core",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/pact-foundation/pact-js-core.git"
+  },
+  "scripts": {},
+  "author": "Yousaf Nabi <you@saf.dev>",
+  "homepage": "https://github.com/pact-foundation/pact-js-core#readme",
+  "os": [
+    "${node_pkg_os}"
+  ],
+  ${libc}
+  "cpu": [
+    "${node_arch}"
+  ]
+}

--- a/script/ci/build-and-test.sh
+++ b/script/ci/build-and-test.sh
@@ -19,11 +19,17 @@ fi
 
 node --version
 npm --version
+# Update main package.json optional dependencies versions, with those created earlier
+current_platform=$("$SCRIPT_DIR"/build-opt-dependencies.sh determine_platform)
+supported_platforms="$current_platform" "$SCRIPT_DIR"/build-opt-dependencies.sh update
+# update lockfile post building updated opt deps
+npm ci --ignore-scripts || npm i --ignore-scripts
+# Link os/arch specific npm package, for running os/arch system
 
-npm ci --ignore-scripts
-
+supported_platforms="$current_platform" "$SCRIPT_DIR"/build-opt-dependencies.sh link
+# ensure we test against the linked npm package, not the prebuild
+rm -rf prebuilds
 npm run format:check
 npm run lint
 npm run build
 npm run test
-ls -1

--- a/script/ci/build-opt-dependencies.sh
+++ b/script/ci/build-opt-dependencies.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+export bin=@pact-foundation/pact-core
+export pkg_version=${pkg_version:-$(cat package.json | jq -r .version)}
+
+if [ -z "${supported_platforms+x}" ]; then
+	supported_platforms=("linux-x64-glibc" "linux-arm64-glibc" "linux-x64-musl" "linux-arm64-musl" "darwin-x64" "darwin-arm64" "windows-x64")
+fi
+
+setup_package_vars(){
+		unset node_os
+		unset node_arch
+		unset node_libc
+		unset libc
+		IFS='-' read -r node_os node_arch node_libc <<< "$supported_platform"
+		export node_os=$node_os
+		export node_pkg_os=$node_os
+		export node_arch=$node_arch
+		export node_libc=$node_libc
+		export prebuild_package="$node_os-$node_arch"
+		# we need to overwrite windows as win32 in the package.json
+		if [ "$node_os" = "windows" ]; then
+			export node_pkg_os=win32
+			export prebuild_package="win32-$node_arch"
+		fi
+		if [ "$node_libc" = "glibc" ]; then
+			export libc='"libc": ["glibc"],'
+		fi
+		if [ "$node_libc" = "musl" ]; then
+			export libc='"libc": ["musl"],'
+		fi
+		export standalone_package=prebuilds/$prebuild_package
+		if [ "$node_libc" = "musl" ] || [ "$node_libc" = "glibc" ]; then
+			export node_pkg=${bin}-$node_os-$node_arch-$node_libc
+		else
+			export node_pkg=${bin}-$node_os-$node_arch
+		fi
+}
+
+clean() {
+	rm -rf @pact-foundation
+	npm run clean-libs
+}
+
+libs() {
+	echo $1
+	if [ -n "$1" ]; then
+		tag=$1
+	else
+		tag=v${pkg_version}
+	fi
+	FETCH_ASSETS=true ./script/ci/check-release-libs.sh --fetch-assets -t $tag
+}
+
+build() {
+	for supported_platform in "${supported_platforms[@]}"; do
+		setup_package_vars
+		echo "Building for $node_os-$node_arch"
+		echo "Building $node_pkg"
+		echo "Build $node_libc"
+		mkdir -p "$node_pkg/prebuilds"
+		cp -R "$standalone_package" "$node_pkg/prebuilds"
+		if [ "$node_libc" = "glibc" ]; then
+			find "$node_pkg/prebuilds" -type f -name '*musl*' -exec rm -f {} +
+		fi
+		if [ "$node_libc" = "musl" ]; then
+			find "$node_pkg/prebuilds" -type f ! -name '*musl*' -exec rm -f {} +
+		fi
+		envsubst < package.json.tmpl > "$node_pkg/package.json"
+		if [ "${PUBLISH:-false}" = true ]; then
+			(cd $node_pkg && npm publish --access public)
+		else
+			(cd $node_pkg && npm publish --access public --dry-run)
+		fi
+	done
+}
+
+update() {
+	for supported_platform in "${supported_platforms[@]}"; do
+		setup_package_vars
+		jq '.optionalDependencies."'$node_pkg'" = "'$pkg_version'"' package.json > package-new.json
+		mv package-new.json package.json
+	done
+}
+
+publish() {
+	set -eu
+	for supported_platform in "${supported_platforms[@]}"; do
+		setup_package_vars
+		echo "Building for $node_os-$node_arch"
+		echo "Building $node_pkg for $node_os-$node_arch"
+		if [ "${PUBLISH:-false}" = true ]; then
+			(cd $node_pkg && npm publish --access public)
+		else
+			(cd $node_pkg && npm publish --access public --dry-run)
+		fi
+	done
+}
+
+link() {
+	set -eu
+	for supported_platform in "${supported_platforms[@]}"; do
+		setup_package_vars
+		(cd $node_pkg && npm link || echo "cannot link for platform")
+		npm link $node_pkg || echo "cannot link for platform"
+	done
+}
+
+determine_platform(){
+	case "$(uname -s)" in
+    Linux)
+        if [ "$(uname -m)" == "x86_64" ]; then
+            if [ -f /etc/os-release ] && grep -q 'Alpine' /etc/os-release; then
+                current_platform="linux-x64-musl"
+            else
+                current_platform="linux-x64-glibc"
+            fi
+        elif [ "$(uname -m)" == "aarch64" ]; then
+            if [ -f /etc/os-release ] && grep -q 'Alpine' /etc/os-release; then
+                current_platform="linux-arm64-musl"
+            else
+                export current_platform="linux-arm64-glibc"
+            fi
+        fi
+        ;;
+    Darwin)
+        if [ "$(uname -m)" == "x86_64" ]; then
+            export current_platform="darwin-x64"
+        elif [ "$(uname -m)" == "arm64" ]; then
+            export current_platform="darwin-arm64"
+        fi
+        ;;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+        export current_platform="windows-x64"
+        ;;
+    *)
+        echo "Unsupported platform: $(uname -s)"
+        exit 1
+        ;;
+	esac
+	if [ -z "$current_platform" ]; then
+		echo "Error: could not determine current_platform"
+		exit 1
+	fi
+	echo $current_platform
+}
+
+help() {
+	echo "Pact platform/arch specific dependency builder"
+
+	echo "Usage: $0 {clean|libs|build_opt_deps|update_opt_deps|publish_opt_package|link|determine_platform|help}"
+	echo
+	echo "Functions:"
+	echo "  clean                - Clean the build environment"
+	echo "  libs                 - Fetch and check release libraries"
+	echo "  build_opt_deps       - Build optional dependencies for supported platforms"
+	echo "  update_opt_deps      - Update optional dependencies in package.json"
+	echo "  publish_opt_package  - Publish the optional package"
+	echo "  link                 - Link the package for development"
+	echo "  determine_platform   - Determine the current platform"
+	echo "  help                 - Display this help message"
+
+	echo
+	echo "Supported platforms:"
+	for platform in "${supported_platforms[@]}"; do
+		echo "  - $platform"
+	done
+	echo
+	echo "Example to run for the current platform:"
+	echo '  supported_platforms=$(./script/ci/build_opt_dependencies.sh determine_platform) ./script/ci/build_opt_dependencies.sh link'
+}
+
+if [ $# -eq 0 ]; then
+	help
+	exit 1
+fi
+
+"$@"

--- a/script/ci/check-release-libs.sh
+++ b/script/ci/check-release-libs.sh
@@ -69,7 +69,7 @@ if [[ "$TAG" == "" ]]; then
 else
     GH_TAG_OPTION="$TAG"
     if [[ "$TAG" == "latest" ]]; then
-        GH_TAG_OPTION=''
+        GH_TAG_OPTION=$(gh release list --limit 1 --repo pact-foundation/pact-js-core --json tagName --jq '.[].tagName')
     fi
 
     if [[ "${LIST_ASSETS:-}" = true || "${FETCH_ASSETS:-}" = true ]]; then

--- a/script/ci/lib/publish.sh
+++ b/script/ci/lib/publish.sh
@@ -6,20 +6,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the 
 
 require_binary npm
 
-VERSION="$("$SCRIPT_DIR/get-version.sh")"
-
 echo "--> Releasing version ${VERSION}"
 
 echo "--> Releasing artifacts"
 echo "    Publishing pact-core@${VERSION}..."
 if [[ ${DRY_RUN:-} == 'true' ]]; then
   echo "publishing in dry run mode"
+  # Dry-run Publish os/arch specific npm packages
+  "$SCRIPT_DIR"/../build-opt-dependencies.sh publish
   npm publish --access-public --dry-run
  else
   echo "--> Preparing npmrc file"
   "$SCRIPT_DIR"/create_npmrc_file.sh
   echo "--> Removing binding.gyp to prevent rebuild. See https://github.com/npm/cli/issues/5234#issuecomment-1291139150"
   rm "${SCRIPT_DIR}/../../../binding.gyp"
+  # Publish os/arch specific npm packages
+  PUBLISH=true "$SCRIPT_DIR"/../build-opt-dependencies.sh publish
   npm publish --access public --tag latest
 fi
 echo "    done!"

--- a/script/ci/prebuild-alpine.sh
+++ b/script/ci/prebuild-alpine.sh
@@ -12,7 +12,7 @@ apk add bash curl python3 make g++
 . "${SCRIPT_DIR}/../lib/export-binary-versions.sh"
 "${SCRIPT_DIR}/../lib/download-ffi.sh"
 rm -rf build node_modules
-npm ci --ignore-scripts
+npm ci --ignore-scripts || npm i --ignore-scripts
 export npm_config_target=${NODE_VERSION}
 
 npx --yes prebuildify@${PREBUILDIFY_VERSION} --napi --libc musl --strip --tag-libc --name ${PREBUILD_NAME}

--- a/script/ci/prebuild.sh
+++ b/script/ci/prebuild.sh
@@ -1,4 +1,4 @@
-# !/bin/bash -eu
+#!/bin/bash -eu
 set -e # This needs to be here for windows bash, which doesn't read the #! line above
 set -u
 
@@ -35,7 +35,7 @@ echo "OS: $OS"
 echo "ARCH: $ARCH"
 
 ./script/download-libs.sh
-npm ci --ignore-scripts
+npm ci --ignore-scripts || npm i --ignore-scripts
 export npm_config_target=${NODE_VERSION}
 npx --yes prebuildify@${PREBUILDIFY_VERSION} --napi --name ${PREBUILD_NAME}
 ls prebuilds/**/*

--- a/script/ci/unpack-and-test.sh
+++ b/script/ci/unpack-and-test.sh
@@ -5,9 +5,16 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)" # Figure out where the script is running
 . "$SCRIPT_DIR"/../lib/robust-bash.sh
 
-ls -1
-mkdir -p prebuilds
-mv artifact*/*.tar.gz .
-ls *.gz |xargs -n1 tar -xzf
+if [ ! -d "prebuilds" ]; then
+    ls -1
+    ls -1 artifact*
+    mkdir -p prebuilds
+    mv artifact*/*.tar.gz .
+    ls *.gz | xargs -n1 tar -xzf
+fi
+
 "$SCRIPT_DIR"/../download-plugins.sh
+# Use the determined platform
+current_platform=$("$SCRIPT_DIR"/build-opt-dependencies.sh determine_platform)
+supported_platforms="$current_platform" "$SCRIPT_DIR"/build-opt-dependencies.sh build
 "$SCRIPT_DIR"/build-and-test.sh

--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -1,10 +1,54 @@
 import path from 'node:path';
 import bindings = require('node-gyp-build');
+import { isNonGlibcLinuxSync } from 'detect-libc';
 import logger, { DEFAULT_LOG_LEVEL } from '../logger';
 import { LogLevel } from '../logger/types';
 import { Ffi, FfiLogLevelFilter } from './types';
 
 export const PACT_FFI_VERSION = '0.4.22';
+
+/**
+ * Returns the library path which is located inside `node_modules`
+ * The naming convention is @pact-foundation/pact-core-${os}-${arch}<-${libc}>
+ * - "-${libc}" is optional for linux only
+ * @see https://nodejs.org/api/os.html#osarch
+ * @see https://nodejs.org/api/os.html#osplatform
+ * @example "x/xx/node_modules/@pact-foundation/pact-core-darwin-arm64"
+ */
+function getPlatformArchSpecificPackage() {
+  const { arch } = process;
+  let os = process.platform as string;
+  if (['win32', 'cygwin'].includes(process.platform)) {
+    os = 'windows';
+  }
+  let platformArchSpecificPackage = `@pact-foundation/pact-core-${os}-${arch}`;
+  if (os === 'linux') {
+    platformArchSpecificPackage += isNonGlibcLinuxSync() ? '-musl' : '-glibc';
+  }
+
+  const prebuildPackageLocation = process.env['PACT_PREBUILD_PACKAGE_LOCATION'];
+  if (prebuildPackageLocation) {
+    platformArchSpecificPackage = path.join(
+      prebuildPackageLocation,
+      platformArchSpecificPackage
+    );
+  }
+
+  const packagePath = `${platformArchSpecificPackage}/package.json`;
+  try {
+    let resolvedPackagePath = require.resolve(packagePath);
+    if (os === 'windows') {
+      resolvedPackagePath = resolvedPackagePath.replace('\\package.json', '');
+    } else {
+      resolvedPackagePath = resolvedPackagePath.replace('/package.json', '');
+    }
+    return resolvedPackagePath;
+  } catch (e) {
+    throw new Error(
+      `Couldn't find npm package ${platformArchSpecificPackage} \n 💡 you can tell Pact where the npm package is located with env var $PACT_PREBUILD_PACKAGE_LOCATION`
+    );
+  }
+}
 
 // supported prebuilds
 // darwin-arm64
@@ -54,7 +98,7 @@ const bindingsResolver = (bindingsPath: string | undefined) =>
   bindings(bindingsPath);
 
 const bindingPaths = [
-  path.resolve(__dirname, '..', '..'),
+  path.resolve(getPlatformArchSpecificPackage()),
   process.env['PACT_PREBUILD_LOCATION']?.toString() ?? path.resolve(),
 ];
 let ffiLib: Ffi;


### PR DESCRIPTION
The following PR will fix #602 

## support libpact_ffi & pact-js-core node bindings to be published in seperate npm packages.

these are segmented by `${os}-{arch}-{libc}`

users should not need to require these automatically, npm should determine the required
optional dependency to download at install time.

supported_platforms

    "@pact-foundation/pact-core-darwin-arm64": "16.0.0",
    "@pact-foundation/pact-core-darwin-x64": "16.0.0",
    "@pact-foundation/pact-core-linux-arm64-glibc": "16.0.0",
    "@pact-foundation/pact-core-linux-arm64-musl": "16.0.0",
    "@pact-foundation/pact-core-linux-x64-glibc": "16.0.0",
    "@pact-foundation/pact-core-linux-x64-musl": "16.0.0",
    "@pact-foundation/pact-core-windows-x64": "16.0.0"

## CI Improvements

Significant build time reductions, by reducing the times when prebuilds are created.

- libpact_ffi node bindings as prebuilds will only be created on master
- test suite will download the latest release prebuilds via gh cli, if not on a master branch

This could be further improved to

- build node bindings & prebuilds, on pull requests, where
  - the libpact_ffi version has changed
  - the code in `native` or the `bindings.gyp` changes 
- allow top level job conditional skipping.
   - it appears you cannot skip an entire job based on a condition, which is a pre-requisite for another job, so you have to nested the condition at each step level.

## Testing

Consumed in pact-js, via scoped publish, shown tested in following forked PR

- https://github.com/YOU54F/pact-js/pull/3

Published for testing

```sh
"@you54f/pact": "14.0.1",
"@you54f/pact-core": "17.0.4",
"@you54f/pact-core-darwin-arm64": "17.0.4",
"@you54f/pact-core-darwin-x64": "17.0.4",
"@you54f/pact-core-linux-arm64-glibc": "17.0.4",
"@you54f/pact-core-linux-arm64-musl": "17.0.4",
"@you54f/pact-core-linux-x64-glibc": "17.0.4",
"@you54f/pact-core-linux-x64-musl": "17.0.4",
"@you54f/pact-core-windows-x64": "17.0.4",

```

Tested with

- npm (works from node 16+)
- yarn pnp (berry) - latest stable (works from node 18+)
- pnpm (works from node 18+)

```yml
      matrix:
        node-version: [16, 18, 20, 22]
        npm_package_manager:
          - yarn
          - pnpm
          - npm
        os: [
            macos-13,
            macos-15,
            ubuntu-24.04,
            ubuntu-24.04-arm,
            windows-latest
          ]
        exclude:
          - npm_package_manager: yarn
            node-version: 16
          - npm_package_manager: pnpm
            node-version: 16
```

See example workflow / simple project

https://github.com/YOU54F/pact-js-packagers-test/blob/main/.github/workflows/test.yml
