### PR TITLE
fix: surface errors from pactffiPluginInteractionContents (rebuild)

### DIFF
--- a/native/addon.cc
+++ b/native/addon.cc
@@ -45,6 +45,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set(Napi::String::New(env, "pactffiSetTestRunId"), Napi::Function::New(env, PactffiSetTestRunId));
   exports.Set(Napi::String::New(env, "pactffiCleanupPlugins"), Napi::Function::New(env, PactffiCleanupPlugins));
   exports.Set(Napi::String::New(env, "pactffiPluginInteractionContents"), Napi::Function::New(env, PactffiPluginInteractionContents));
+  exports.Set(Napi::String::New(env, "pactffiGetErrorMessage"), Napi::Function::New(env, PactffiGetErrorMessage));
 
   // exports.Set(Napi::String::New(env, "pactffiNewMessagePact"), Napi::Function::New(env, PactffiNewMessagePact));
   // exports.Set(Napi::String::New(env, "pactffiWriteMessagePactFile"), Napi::Function::New(env, PactffiWriteMessagePactFile));

--- a/native/consumer.cc
+++ b/native/consumer.cc
@@ -1,4 +1,7 @@
 #include <napi.h>
+#include <algorithm>
+#include <string>
+#include <vector>
 #include "pact-cpp.h"
 
 
@@ -2191,9 +2194,52 @@ Napi::Value PactffiPluginInteractionContents(const Napi::CallbackInfo& info) {
   std::string contentType = info[2].As<Napi::String>().Utf8Value();
   std::string contents = info[3].As<Napi::String>().Utf8Value();
 
-  bool res = pactffi_interaction_contents(interaction, part, contentType.c_str(), contents.c_str());
+  // NOTE: pactffi_interaction_contents returns an unsigned int status code where
+  // zero means success and any positive value is an error (see pact.h). It must
+  // not be coerced to a bool: that maps 0 (success) to false and 6 (the plugin
+  // returned an error) to true, i.e. exactly backwards. Return the code as-is and
+  // let the caller check it against zero.
+  unsigned int res = pactffi_interaction_contents(interaction, part, contentType.c_str(), contents.c_str());
 
-  return Napi::Boolean::New(env, res);
+  return Napi::Number::New(env, res);
+}
+
+/**
+ * Provide the most recent error message, if there is one.
+ *
+ * Many FFI functions signal failure by returning a non-zero status code and
+ * storing the detail in LAST_ERROR. Without access to this, callers can only
+ * report the numeric code, which is rarely actionable — particularly for plugin
+ * errors, where the useful text comes from the plugin itself.
+ *
+ * Returns the message, or an empty string when there is no error to report.
+ *
+ * C interface:
+ *
+ * int pactffi_get_error_message(char *buffer, size_t length);
+ */
+Napi::Value PactffiGetErrorMessage(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  // pactffi_get_error_message writes into a caller-supplied buffer and returns
+  // the number of bytes written, 0 when there is no error, or a negative value
+  // on failure.
+  std::vector<char> buffer(1024, '\0');
+  int written = pactffi_get_error_message(buffer.data(), buffer.size());
+
+  if (written <= 0) {
+    return Napi::String::New(env, "");
+  }
+
+  // Guard against a length that would run past the buffer, and stop at the first
+  // NUL so a partially-filled buffer does not leak trailing zero bytes.
+  size_t length = std::min(static_cast<size_t>(written), buffer.size());
+  size_t end = 0;
+  while (end < length && buffer[end] != '\0') {
+    end++;
+  }
+
+  return Napi::String::New(env, std::string(buffer.data(), end));
 }
 
 /**

--- a/src/consumer/index.ts
+++ b/src/consumer/index.ts
@@ -2,6 +2,7 @@ import { getFfiLib } from '../ffi';
 import {
   CREATE_MOCK_SERVER_ERRORS,
   type Ffi,
+  type FfiInteractionPart,
   type FfiSpecificationVersion,
   INTERACTION_PART_REQUEST,
   INTERACTION_PART_RESPONSE,
@@ -23,6 +24,52 @@ import type {
   SynchronousMessage,
 } from './types';
 
+const PLUGIN_INTERACTION_CONTENTS_ERRORS: Record<number, string> = {
+  1: 'a general panic was caught',
+  2: 'the mock server has already been started',
+  3: 'the interaction handle is invalid',
+  4: 'the content type is not valid',
+  5: 'the contents are not valid JSON',
+  6: 'the plugin returned an error',
+};
+
+/**
+ * Configures part of an interaction via a plugin, throwing if the FFI reports a
+ * failure.
+ *
+ * `pactffiPluginInteractionContents` returns zero on success and a positive
+ * status code on failure, with the detail in LAST_ERROR. Previously the result
+ * was discarded, so a plugin rejecting the supplied configuration produced a
+ * silently mis-recorded interaction (a part with no body) and a passing test.
+ */
+const setPluginInteractionContents = (
+  ffi: Ffi,
+  interactionPtr: number,
+  part: FfiInteractionPart,
+  contentType: string,
+  contents: string,
+): boolean => {
+  const code = ffi.pactffiPluginInteractionContents(
+    interactionPtr,
+    part,
+    contentType,
+    contents,
+  );
+
+  if (code !== 0) {
+    const detail = ffi.pactffiGetErrorMessage();
+    const reason =
+      PLUGIN_INTERACTION_CONTENTS_ERRORS[code] ?? `unknown error (${code})`;
+    logErrorAndThrow(
+      `Failed to set plugin interaction contents for content type '${contentType}': ${reason}${
+        detail ? `: ${detail}` : ''
+      }`,
+    );
+  }
+
+  return true;
+};
+
 const asyncMessage = (
   ffi: Ffi,
   interactionPtr: number,
@@ -36,13 +83,13 @@ const asyncMessage = (
     contentType: string,
     contents: string,
   ) => {
-    ffi.pactffiPluginInteractionContents(
+    return setPluginInteractionContents(
+      ffi,
       interactionPtr,
       INTERACTION_PART_REQUEST,
       contentType,
       contents,
     );
-    return true;
   },
   expectsToReceive: (description: string) =>
     ffi.pactffiMessageExpectsToReceive(interactionPtr, description),
@@ -226,37 +273,37 @@ export const makeConsumerPact = (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_REQUEST,
             contentType,
             contents,
           );
-          return true;
         },
         withPluginResponseInteractionContents: (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_RESPONSE,
             contentType,
             contents,
           );
-          return true;
         },
         withPluginRequestResponseInteractionContents: (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_REQUEST,
             contentType,
             contents,
           );
-          return true;
         },
         given: (state: string) => ffi.pactffiGiven(interactionPtr, state),
         givenWithParam: (state: string, name: string, value: string) =>
@@ -503,39 +550,37 @@ export const makeConsumerPact = (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_REQUEST,
             contentType,
             contents,
           );
-
-          return true;
         },
         withPluginRequestResponseInteractionContents: (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_REQUEST,
             contentType,
             contents,
           );
-
-          return true;
         },
         withPluginResponseInteractionContents: (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_RESPONSE,
             contentType,
             contents,
           );
-          return true;
         },
       });
     },
@@ -621,37 +666,37 @@ export const makeConsumerMessagePact = (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_REQUEST,
             contentType,
             contents,
           );
-          return true;
         },
         withPluginResponseInteractionContents: (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_RESPONSE,
             contentType,
             contents,
           );
-          return true;
         },
         withPluginRequestResponseInteractionContents: (
           contentType: string,
           contents: string,
         ) => {
-          ffi.pactffiPluginInteractionContents(
+          return setPluginInteractionContents(
+            ffi,
             interactionPtr,
             INTERACTION_PART_REQUEST,
             contentType,
             contents,
           );
-          return true;
         },
         given: (state: string) => ffi.pactffiGiven(interactionPtr, state),
         givenWithParam: (state: string, name: string, value: string) =>

--- a/src/ffi/index.ts
+++ b/src/ffi/index.ts
@@ -6,7 +6,7 @@ import { type Ffi, FfiLogLevelFilter } from './types';
 
 const bindings = require('node-gyp-build') as (dir?: string) => Ffi;
 
-export const PACT_FFI_VERSION = '0.5.6';
+export const PACT_FFI_VERSION = '0.5.7';
 
 /**
  * Returns the library path which is located inside `node_modules`

--- a/src/ffi/types.ts
+++ b/src/ffi/types.ts
@@ -248,12 +248,21 @@ export type FfiConsumerFunctions = {
   ): FfiConfigurePluginResponse;
   pactffiSetTestRunId(testRunId: string): void;
   pactffiCleanupPlugins(handle: FfiPactHandle): void;
+  /**
+   * Configures a part of an interaction via a plugin.
+   *
+   * Returns a status code: zero on success, a positive value on failure (`6`
+   * meaning the plugin itself returned an error). Call `pactffiGetErrorMessage`
+   * for the detail.
+   */
   pactffiPluginInteractionContents(
     handle: FfiInteractionHandle,
     part: FfiInteractionPart,
     contentType: string,
     contents: string,
-  ): void;
+  ): number;
+  /** The most recent FFI error message, or an empty string if there is none. */
+  pactffiGetErrorMessage(): string;
   pactffiNewAsyncMessage(
     handle: FfiPactHandle,
     description: string,

--- a/test/consumer.integration.spec.ts
+++ b/test/consumer.integration.spec.ts
@@ -636,6 +636,47 @@ describe('FFI integration test for the HTTP Consumer API', () => {
     },
   );
 
+  describe('when setting plugin interaction contents fails', () => {
+    // The FFI reports failure with a non-zero status code rather than by
+    // throwing. That result used to be discarded, so a rejected configuration
+    // silently produced an interaction with no body and a still-passing test.
+    // Neither case below needs a plugin installed: the contents are rejected
+    // before any plugin is consulted.
+    beforeEach(() => {
+      pact = makeConsumerPact(
+        'foo-consumer',
+        'bar-provider',
+        FfiSpecificationVersion.SPECIFICATION_VERSION_V4,
+      );
+    });
+
+    it('throws when the contents are not valid JSON', () => {
+      const interaction = pact.newInteraction('some description');
+      interaction.uponReceiving('a request with unparseable plugin contents');
+      interaction.withRequest('GET', '/broken');
+
+      expect(() =>
+        interaction.withPluginRequestInteractionContents(
+          'application/json',
+          'this is not JSON',
+        ),
+      ).toThrowError(/not valid JSON/);
+    });
+
+    it('throws when the content type is not valid', () => {
+      const interaction = pact.newInteraction('some description');
+      interaction.uponReceiving('a request with an invalid content type');
+      interaction.withRequest('GET', '/broken');
+
+      expect(() =>
+        interaction.withPluginResponseInteractionContents(
+          'not a content type',
+          JSON.stringify({ some: 'contents' }),
+        ),
+      ).toThrowError(/content type is not valid/);
+    });
+  });
+
   describe('with multipart data', () => {
     const form = new FormData();
     const f: string = path.resolve(__dirname, './monkeypatch.rb');


### PR DESCRIPTION
`pactffi_interaction_contents` returns an unsigned status code (0 = success, positive = failure, 6 meaning the plugin itself rejected the configuration) and records the detail in `LAST_ERROR`. Multiple layers obstructed and discard this result:

- `native/consumer.cc` assigned the status to a `bool`, which maps 0 (success) to `false` and 6 (plugin error) to `true` — exactly backwards;
- `src/ffi/types.ts` declared the function as returning `void`;
- `src/consumer/index.ts` ignored the result at all ten call sites and hardcoded `return true`.

The net effect was that a plugin rejecting the supplied configuration produced no error, and the interaction was recorded with the affected part left empty. The consumer test then passed and wrote a silently corrupt pact.

Return the status code from the native binding, expose `pactffi_get_error_message` (already declared in consumer.h but never implemented or exported) so the plugin's own message is reachable, and throw from a shared helper when the code is non-zero.

Note that the native and JS changes must ship together: new JS against an old prebuilt would read a boolean where it expects a status code.

